### PR TITLE
kind/feature: Changing ClusterResourceSets Rolloutstrategy from ApplyOnce to Reconcile

### DIFF
--- a/templates/cluster-template-kubeadm.yaml
+++ b/templates/cluster-template-kubeadm.yaml
@@ -171,7 +171,7 @@ spec:
   resources:
   - kind: ConfigMap
     name: cloud-controller-manager-addon
-  strategy: ApplyOnce
+  strategy: Reconcile
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -185,7 +185,7 @@ spec:
   resources:
   - kind: ConfigMap
     name: harvester-csi-driver-addon
-  strategy: ApplyOnce
+  strategy: Reconcile
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/templates/cluster-template-rke2.yaml
+++ b/templates/cluster-template-rke2.yaml
@@ -157,7 +157,7 @@ spec:
   resources:
   - kind: ConfigMap
     name: cloud-controller-manager-addon
-  strategy: ApplyOnce
+  strategy: Reconcile
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -171,7 +171,7 @@ spec:
   resources:
   - kind: ConfigMap
     name: harvester-csi-driver-addon
-  strategy: ApplyOnce
+  strategy: Reconcile
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -185,7 +185,7 @@ spec:
   resources:
   - kind: ConfigMap
     name: calico-helm-config
-  strategy: ApplyOnce
+  strategy: Reconcile
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the way we configure the ClusterResourceSets Rolloutstrategy from 'ApplyOne' to 'Reconcile'

This ensures, that the desired CRS are always synced back to the attached Clusters (mgmt/workload), so that a User does not need to manually re-create the CRS on the attached clusters if those are being deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #39 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [-] adds unit tests
- [-] adds or updates e2e tests
