### PR TITLE
Update README To Include Missing Workload Cluster Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,19 @@ export CLUSTER_NAME=test-rk # Name of the cluster that will be created.
 export HARVESTER_ENDPOINT=x.x.x.x # Harvester Clusters IP Adr.
 export NAMESPACE=example-rk # Namespace where the cluster will be created.
 export KUBERNETES_VERSION=v1.26.6 # Kubernetes Version
-export SSH_KEYPAIR=<public-key-name> # should exist in Harvester prior to applying manifest
-export VM_IMAGE_NAME=default/jammy-server-cloudimg-amd64.img # Should have the format <NAMESPACE>/<NAME> for an image that exists on Harvester
+export SSH_KEYPAIR=<public-key-name> # should exist in Harvester prior to applying manifest. Should have the format <TARGET_HARVESTER_NAMESPACE>/<NAME>
+export VM_IMAGE_NAME=default/jammy-server-cloudimg-amd64.img # Should have the format <TARGET_HARVESTER_NAMESPACE>/<NAME> for an image that exists on Harvester
 export CONTROL_PLANE_MACHINE_COUNT=3
 export WORKER_MACHINE_COUNT=2
 export VM_DISK_SIZE=40Gi # Put here the desired disk size
 export RANCHER_TURTLES_LABEL='' # This is used if you are using Rancher CAPI Extension (Turtles) to import the cluster automatically.
-export VM_NETWORK=default/untagged # change here according to your Harvester available VM Networks
+export VM_NETWORK=default/untagged # change here according to your Harvester available VM Networks. Should have the format <TARGET_HARVESTER_NAMESPACE>/<NAME>
 export HARVESTER_KUBECONFIG_B64=XXXYYY #Full Harvester's kubeconfig encoded in Base64. You can use: cat kubeconfig.yaml | base64
 export CLOUD_CONFIG_KUBECONFIG_B64=ZZZZAAA # Kubeconfig generated for the Cloud Provider: https://docs.harvesterhci.io/v1.3/rancher/cloud-provider#deploying-to-the-rke2-custom-cluster-experimental 
+export IP_POOL_NAME=default # for the non-DHCP template, specify the IP pool for the Harvester load balancer. The IP pool must exist in Harvester prior to applying manifest
+export TARGET_HARVESTER_NAMESPACE=default # the namespace on the Harvester cluster where the VMs, load balancers etc. should be created
 ```
+
 NOTE: The `CLOUD_CONFIG_KUBECONFIG_B64` variable content should be the result of the script available [here](https://docs.harvesterhci.io/v1.3/rancher/cloud-provider#deploying-to-the-rke2-custom-cluster-experimental) -- meaning, the generated kubeconfig -- encoded in BASE64.
 
 Now, we can generate the YAML using the following command:

--- a/templates/cluster-template-rke2-dhcp.yaml
+++ b/templates/cluster-template-rke2-dhcp.yaml
@@ -29,7 +29,7 @@ metadata:
   name: ${CLUSTER_NAME}-hv
   namespace: ${NAMESPACE}
 spec:
-  targetNamespace: default
+  targetNamespace: ${TARGET_HARVESTER_NAMESPACE}
   loadBalancerConfig:
     ipamType: dhcp
     listeners:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

This PR updates the README with these changes:

* Include the missing `IP_POOL_NAME` and `TARGET_HARVESTER_NAMESPACE` settings needed to run the `template/cluster-template-rke2.yaml` template. Without this change, the provided `clusterctl generate yaml` command would fail as follows:

```sh
$ clusterctl generate yaml --from https://github.com/rancher-sandbox/cluster-api-provider-harvester/blob/main/templates/cluster-template-rke2.yaml > harvester-rke2-clusterctl.yaml
Error: value for variables [IP_POOL_NAME, TARGET_HARVESTER_NAMESPACE] is not set. Please set the value using os environment variables or the clusterctl config file
```

* Update the usage comment of the `SSH_KEYPAIR` environment variable to include the key's namespace. If the keypair isn't in the `harvester-system` namespace, its namespace needs to be specified. See [1]. Without this change, the `caphv-system/caphv-controller-manager` pod will error with:

```sh
2024-11-18T23:20:54Z    ERROR   Reconciler error        {"controller": "harvestermachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "HarvesterMachine", "HarvesterMachine": {"name":"capi-demo-cp-machine-5x29j","namespace":"gc-rke2"}, "namespace": "gc-rke2", "name": "capi-demo-cp-machine-5x29j", "reconcileID": "92b09c51-07d9-4800-af61-3386156639e6", "error": "unable to build VM definition: no keypair could be found in namespace harvester-system, keypair was only referenced by name id-ecdsa, \ntry to specify the namespace using the format <NAMESPACE>/<NAME>", "errorVerbose": "no keypair could be found in namespace harvester-system, keypair was only referenced by name id-ecdsa, \ntry to specify the namespace using the format <NAMESPACE>/<NAME>\nunable to build VM definition\ngithub.com/rancher-sandbox/cluster-api-provider-harvester/controllers.createVMFromHarvesterMachine\n\t/workspace/controllers/harvestermachine_controller.go:483\ngithub.com/rancher-sandbox/cluster-api-provider-harvester/controllers.(*HarvesterMachineReconciler).ReconcileNormal\n\t/workspace/controllers/harvestermachine_controller.go:332\ngithub.com/rancher-sandbox/cluster-api-provider-harvester/controllers.(*HarvesterMachineReconciler).Reconcile\n\t/workspace/controllers/harvestermachine_controller.go:198\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


[1]: https://github.com/rancher-sandbox/cluster-api-provider-harvester/blob/42e3cfca0e215493789c01ff757a6e74cf2974c5/util/util.go#L141-L160