### PR TITLE
fix: update the RKE2 worker machine templates to use the correct RKE2 version

### DIFF
--- a/templates/cluster-template-rke2-dhcp.yaml
+++ b/templates/cluster-template-rke2-dhcp.yaml
@@ -104,7 +104,7 @@ spec:
         kind: HarvesterMachineTemplate
         name: ${CLUSTER_NAME}-wk-machine
         namespace: ${NAMESPACE}
-      version: ${KUBERNETES_VERSION}
+      version: ${KUBERNETES_VERSION}+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: HarvesterMachineTemplate

--- a/templates/cluster-template-rke2.yaml
+++ b/templates/cluster-template-rke2.yaml
@@ -105,7 +105,7 @@ spec:
         kind: HarvesterMachineTemplate
         name: ${CLUSTER_NAME}-wk-machine
         namespace: ${NAMESPACE}
-      version: ${KUBERNETES_VERSION}
+      version: ${KUBERNETES_VERSION}+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: HarvesterMachineTemplate


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

The worker machine's RKE2 version used in the templates seem to be missing the `+rke2r1` suffix. In my testing, the RKE2 worker nodes failed to join the workload cluster:

```sh
$ k -n gc-rke2 get cluster,harvestercluster,rke2controlplane,machinedeployment,machine
NAME                                 CLUSTERCLASS   PHASE         AGE   VERSION
cluster.cluster.x-k8s.io/capi-demo                  Provisioned   21h

NAME                                                            READY   SERVER
harvestercluster.infrastructure.cluster.x-k8s.io/capi-demo-hv   true    https://x.x.x.x:6443

NAME                                                                     AGE
rke2controlplane.controlplane.cluster.x-k8s.io/capi-demo-control-plane   21h

NAME                                                   CLUSTER     REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE       AGE   VERSION
machinedeployment.cluster.x-k8s.io/capi-demo-workers   capi-demo   3                  3         3             ScalingUp   21h   v1.30.5

NAME                                                     CLUSTER     NODENAME   PROVIDERID                                         PHASE          AGE   VERSION
machine.cluster.x-k8s.io/capi-demo-control-plane-7ksr4   capi-demo              <redacted>                                         Provisioned    21h   v1.30.5+rke2r1
machine.cluster.x-k8s.io/capi-demo-workers-d25tl-8vqdc   capi-demo                                                                 Provisioning   21h   v1.30.5
machine.cluster.x-k8s.io/capi-demo-workers-d25tl-crb7d   capi-demo                                                                 Provisioning   21h   v1.30.5
machine.cluster.x-k8s.io/capi-demo-workers-d25tl-kzs7n   capi-demo                                                                 Provisioning   21h   v1.30.5
```

Notice that the worker nodes' version was set to `v1.30.5`, while the control plane node was `v1.30.5+rke2r1`.

On the worker nodes, cloud-init failed due to an incorrect RKE2 `v1.30.5` download URL:

```sh
$ less /var/log/cloud-init-output.log
[INFO]  using v1.30.5 as release
[INFO]  downloading checksums at https://github.com/rancher/rke2/releases/download/v1.30.5/sha256sum-amd64.txt
curl: (22) The requested URL returned error: 404
Failed to enable unit: Unit file rke2-agent.service does not exist.
Failed to start rke2-agent.service: Unit rke2-agent.service not found.
```

With this fix, the worker nodes' cloud-init is able to find the correct RKE2 `v1.30.5+rke2r1` URL:

```sh
$ less /var/log/cloud-init-output.log
[INFO]  using v1.30.5+rke2r1 as release
[INFO]  downloading checksums at https://github.com/rancher/rke2/releases/download/v1.30.5+rke2r1/sha256sum-amd64.txt
[INFO]  downloading tarball at https://github.com/rancher/rke2/releases/download/v1.30.5+rke2r1/rke2.linux-amd64.tar.gz
[INFO]  verifying tarball
[INFO]  unpacking tarball file to /usr/local
Created symlink /etc/systemd/system/multi-user.target.wants/rke2-agent.service → /usr/local/lib/systemd/system/rke2-agent.service.
Cloud-init v. 24.3.1-0ubuntu0~22.04.1 finished at Tue, 19 Nov 2024 22:24:17 +0000. Datasource DataSourceNoCloud [seed=/dev/vdb].  Up 74.78 seconds
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
