### PR TITLE
fixed RFC1035 naming for generated names and fixed some linting issues

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	namespace             string
+	name                  string
+	expectedResultingName string
+)
+
+var _ = Describe("GenerateNameFromFirstComponentWithDigit", func() {
+
+	BeforeEach(func() {
+		namespace = "1test"
+		name = "test-1"
+
+		expectedResultingName = "a-1test-test-1"
+	})
+
+	It("Should return the right name", func() {
+		name := GenerateRFC1035Name([]string{namespace, name})
+		Expect(name).To(Equal(expectedResultingName))
+	})
+})
+
+var _ = Describe("GenerateNameFromUpperCase", func() {
+	BeforeEach(func() {
+		namespace = "TeStNS"
+		name = "test"
+
+		expectedResultingName = "testns-test"
+	})
+
+	It("Should return the right name", func() {
+		name := GenerateRFC1035Name([]string{namespace, name})
+		Expect(name).To(Equal(expectedResultingName))
+	})
+})
+
+var _ = Describe("GenerateNameLimitedTo63", func() {
+	BeforeEach(func() {
+		namespace = "1TeStNS123"
+		name = "namewith20characters-namewith20characters-namewith20characters"
+
+		expectedResultingName = "a-1testns123-namewith20characters-namewith20characters-namewith"
+	})
+
+	It("Should return the right name", func() {
+		name := GenerateRFC1035Name([]string{namespace, name})
+		Expect(name).To(Equal(expectedResultingName))
+	})
+})


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR changes the way CAPHV generates names for LBs and IP pools in order for them to be compliant with RFC-1035. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
