### PR TITLE
Adding kind/bump to labels of PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "kind/cleanup"
+      - "kind/bump"
       - "area/dependency"
     ignore:
       # Ignore Cluster-API as its upgraded manually.

--- a/.github/workflows/pr_type.yml
+++ b/.github/workflows/pr_type.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: kind/bug,kind/documentation,kind/feature,kind/regression,kind/refactor,kind/cleanup,kind/proposal
+          one_of: kind/bug,kind/documentation,kind/feature,kind/regression,kind/refactor,kind/cleanup,kind/proposal,kind/bump
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For dependabot actions, it is good to separate cleanup from bumps.\nThat's why we are adding this new label to dependabot and PR checks