### PR TITLE
fix: upgrade longhorn csi sidecars version

### DIFF
--- a/templates/cluster-template-rke2-dhcp.yaml
+++ b/templates/cluster-template-rke2-dhcp.yaml
@@ -447,6 +447,8 @@ data:
     kind: StorageClass
     metadata:
       name: harvester
+      annotation:
+        storageclass.kubernetes.io/is-default-class: "true"
     allowVolumeExpansion: true
     provisioner: driver.harvesterhci.io
     reclaimPolicy: Delete

--- a/templates/cluster-template-rke2-dhcp.yaml
+++ b/templates/cluster-template-rke2-dhcp.yaml
@@ -217,7 +217,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /csi/csi.sock
-              image: longhornio/csi-node-driver-registrar:v1.2.0-lh1
+              image: longhornio/csi-node-driver-registrar:v2.12.0
               lifecycle:
                 preStop:
                   exec:
@@ -364,7 +364,7 @@ data:
             - args:
                 - --v=5
                 - --csi-address=$(ADDRESS)
-                - --csiTimeout=2m5s
+                - --timeout=2m5s
                 - --leader-election
                 - --leader-election-namespace=$(POD_NAMESPACE)
               env:
@@ -375,7 +375,7 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-              image: longhornio/csi-resizer:v0.5.1-lh1
+              image: longhornio/csi-resizer:v1.12.0
               name: csi-resizer
               volumeMounts:
                 - mountPath: /csi/
@@ -384,8 +384,7 @@ data:
                 - --v=5
                 - --csi-address=$(ADDRESS)
                 - --timeout=2m5s
-                - --enable-leader-election
-                - --leader-election-type=leases
+                - --leader-election
                 - --leader-election-namespace=$(POD_NAMESPACE)
               env:
                 - name: ADDRESS
@@ -395,7 +394,7 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-              image: longhornio/csi-provisioner:v1.6.0-lh1
+              image: longhornio/csi-provisioner:v5.1.0
               name: csi-provisioner
               volumeMounts:
                 - mountPath: /csi/
@@ -414,7 +413,7 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-              image: longhornio/csi-attacher:v2.2.1-lh1
+              image: longhornio/csi-attacher:v4.7.0
               name: csi-attacher
               volumeMounts:
                 - mountPath: /csi/

--- a/templates/cluster-template-rke2.yaml
+++ b/templates/cluster-template-rke2.yaml
@@ -447,6 +447,8 @@ data:
     kind: StorageClass
     metadata:
       name: harvester
+      annotation:
+        storageclass.kubernetes.io/is-default-class: "true"
     allowVolumeExpansion: true
     provisioner: driver.harvesterhci.io
     reclaimPolicy: Delete

--- a/templates/cluster-template-rke2.yaml
+++ b/templates/cluster-template-rke2.yaml
@@ -218,7 +218,7 @@ data:
               env:
                 - name: ADDRESS
                   value: /csi/csi.sock
-              image: rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
+              image: longhornio/csi-node-driver-registrar:v2.12.0
               lifecycle:
                 preStop:
                   exec:
@@ -375,7 +375,7 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-              image: rancher/mirrored-longhornio-csi-resizer:v1.2.0
+              image: longhornio/csi-resizer:v1.12.0
               name: csi-resizer
               volumeMounts:
                 - mountPath: /csi/
@@ -394,7 +394,7 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-              image: rancher/mirrored-longhornio-csi-provisioner:v2.1.2
+              image: longhornio/csi-provisioner:v5.1.0
               name: csi-provisioner
               volumeMounts:
                 - mountPath: /csi/
@@ -413,7 +413,7 @@ data:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-              image: rancher/mirrored-longhornio-csi-attacher:v3.2.1
+              image: longhornio/csi-attacher:v4.7.0
               name: csi-attacher
               volumeMounts:
                 - mountPath: /csi/


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR updates the RKE2 templates to use newer version of the Longhorn CSI sidecars. Some of these older sidecars are still dependent on the `storage.k8s.io/v1beta1` API, which has been deprecated since K8s 1.27. 

With K8s 1.27+, pods within the RKE2 guest cluster would fail during PVC attachments, because the `csi-attacher` side cars were unable to retrieve the `VolumeAttachments` and `CSINodes` resources from the `v1beta1` paths:

```
I1121 20:47:15.379380       1 round_trippers.go:443] GET https://10.43.0.1:443/apis/storage.k8s.io/v1beta1/volumeattachments?limit=500&resourceVersion=0 404 Not Found in 1 milliseconds
I1121 20:47:15.379397       1 round_trippers.go:449] Response Headers:
I1121 20:47:15.379400       1 round_trippers.go:452]     Cache-Control: no-cache, private
I1121 20:47:15.379402       1 round_trippers.go:452]     Content-Type: application/json
I1121 20:47:15.379404       1 round_trippers.go:452]     X-Kubernetes-Pf-Flowschema-Uid: ba9c3907-b529-4a80-b37c-ddd07b5ad532
I1121 20:47:15.379406       1 round_trippers.go:452]     X-Kubernetes-Pf-Prioritylevel-Uid: a1e11fe2-4166-4da4-a907-98ad17f22cc6
I1121 20:47:15.379409       1 round_trippers.go:452]     Content-Length: 174
I1121 20:47:15.379411       1 round_trippers.go:452]     Date: Thu, 21 Nov 2024 20:47:15 GMT
I1121 20:47:15.379413       1 round_trippers.go:452]     Audit-Id: 62bd9e54-7546-44be-b3f4-1b60c5200a65
I1121 20:47:15.379426       1 request.go:1017] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the server could not find the requested resource","reason":"NotFound","details":{},"code":404}
E1121 20:47:15.379496       1 reflector.go:156] pkg/mod/k8s.io/client-go@v0.17.0/tools/cache/reflector.go:108: Failed to list *v1beta1.VolumeAttachment: the server could not find the requested resource
I1121 20:47:15.380492       1 round_trippers.go:443] GET https://10.43.0.1:443/apis/storage.k8s.io/v1beta1/csinodes?limit=500&resourceVersion=0 404 Not Found in 2 milliseconds
I1121 20:47:15.380964       1 round_trippers.go:449] Response Headers:
I1121 20:47:15.381192       1 round_trippers.go:452]     Date: Thu, 21 Nov 2024 20:47:15 GMT
I1121 20:47:15.381196       1 round_trippers.go:452]     Audit-Id: 43e85ac7-9231-4eae-85d4-060b33a5de58
I1121 20:47:15.381199       1 round_trippers.go:452]     Cache-Control: no-cache, private
I1121 20:47:15.381201       1 round_trippers.go:452]     Content-Type: application/json
I1121 20:47:15.381203       1 round_trippers.go:452]     X-Kubernetes-Pf-Flowschema-Uid: ba9c3907-b529-4a80-b37c-ddd07b5ad532
I1121 20:47:15.381206       1 round_trippers.go:452]     X-Kubernetes-Pf-Prioritylevel-Uid: a1e11fe2-4166-4da4-a907-98ad17f22cc6
I1121 20:47:15.381208       1 round_trippers.go:452]     Content-Length: 174
I1121 20:47:15.381734       1 request.go:1017] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the server could not find the requested resource","reason":"NotFound","details":{},"code":404}
```

The newer versions of the CSI sidecars resolve this issue by using the `storage.k8s.io/v1` API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
