### PR TITLE
docs: clarify cosign v3 requirement for verifying release artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,27 @@ Plan the upgrade in this order:
   a `caphv-generate` manifest, VM provisioned on Harvester (KubeVirt
   1.7.0), IP allocated from `capi-vm-pool`, providerID assigned.
 
+### Verifying release artifacts
+
+`.github/workflows/release.yml` signs the multi-arch image keylessly with
+cosign v3.0.6 using the GitHub Actions OIDC identity, attests SLSA build
+provenance via `actions/attest-build-provenance`, and generates SBOM +
+provenance through `docker/build-push-action`.
+
+> **cosign v3.0.0+ is required to verify.** v0.2.9 and v0.3.0 are signed in
+> the OCI 1.1 bundle format used by cosign v3; older cosign v2 clients
+> report `no signatures found` against these images.
+
+```bash
+cosign verify ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.3.0 \
+  --certificate-identity-regexp "^https://github.com/rancher-sandbox/cluster-api-provider-harvester" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+gh attestation verify \
+  oci://ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.3.0 \
+  --owner rancher-sandbox
+```
+
 ## [v0.2.9] - 2026-04-15
 
 ### Security
@@ -136,7 +157,11 @@ Plan the upgrade in this order:
 
 ### Verifying release artifacts
 
-The container image and helm chart are signed with cosign using GitHub OIDC. Verify with:
+The container image and helm chart are signed with cosign using GitHub OIDC.
+
+> **cosign v3.0.0+ is required.** This release was signed with cosign v3,
+> which stores signatures in the OCI 1.1 bundle format; older cosign v2
+> clients report `no signatures found`.
 
 ```bash
 cosign verify ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.2.9 \
@@ -144,7 +169,14 @@ cosign verify ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.2.9 \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-A SLSA provenance attestation is attached to the registry alongside the image.
+A SLSA provenance attestation is attached to the registry alongside the
+image and can be verified with:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.2.9 \
+  --owner rancher-sandbox
+```
 
 ## [v0.2.8] - 2026-03-16
 

--- a/README.md
+++ b/README.md
@@ -442,6 +442,37 @@ make docker-build IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.
 make test
 ```
 
+## Verifying release artifacts
+
+Container images and SLSA build provenance are produced by
+`.github/workflows/release.yml` and signed keylessly with
+[cosign](https://docs.sigstore.dev/) using the GitHub Actions OIDC
+identity.
+
+> **Requires cosign v3.0.0 or newer.** Releases v0.2.9+ are signed in
+> the OCI 1.1 bundle format used by cosign v3. Older cosign v2 clients
+> report `no signatures found` against these images — install cosign
+> v3 to verify.
+
+Verify the container image:
+
+```bash
+cosign verify ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.3.0 \
+  --certificate-identity-regexp "^https://github.com/rancher-sandbox/cluster-api-provider-harvester" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Verify the SLSA build provenance with the GitHub CLI:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.3.0 \
+  --owner rancher-sandbox
+```
+
+Both checks confirm the image was built from this repository's
+`release.yml` workflow at the matching tag.
+
 ## Release History
 
 | Version | Date | Key changes |


### PR DESCRIPTION
**What this PR does / why we need it**:

Releases v0.2.9 (the first release with cosign signing) and v0.3.0 are
signed by `.github/workflows/release.yml` using cosign v3.0.6. Cosign
v3 stores signatures in the OCI 1.1 bundle format by default, which
older cosign v2 clients do not understand — they report
`no signatures found` against these images even though the signatures
are present and valid.

This PR adds:
- A new "Verifying release artifacts" section in `README.md` with the
  cosign and `gh attestation verify` commands and an explicit
  "requires cosign v3.0.0+" callout.
- The same section under `[v0.3.0]` in `CHANGELOG.md`.
- An equivalent callout retroactively under `[v0.2.9]` in
  `CHANGELOG.md` so that release's existing verification block matches
  the actual on-disk signature format.

Documentation-only — no code changes, no workflow changes, no new
release required.

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests (N/A — docs only)
- [ ] adds or updates e2e tests (N/A — docs only)