### PR TITLE
docs: add cluster pause/resume runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,6 @@ spec:
   name: rke2
   type: controlPlane
 ```
-- Harvester identity Secret (kubeconfig for the target Harvester cluster)
-- SSH KeyPair created on Harvester
-- VM image uploaded to Harvester (SLES 15 SP7 recommended)
-- IPPool configured on Harvester (for automatic IP allocation)
 
 ## Installation
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -440,6 +440,62 @@ kubectl get machines -n my-ns
 kubectl get vm -n <harvester-target-namespace> --kubeconfig <harvester-kubeconfig>
 ```
 
+### Pausing and resuming a cluster (free up Harvester resources)
+
+A CAPHV cluster can be parked without deleting it: the VM disks stay on
+Harvester and the CAPI objects stay on the management cluster, so a resume
+takes minutes instead of a full re-provision.
+
+**Pause:**
+
+```bash
+# 1. Scale workers to zero FIRST, while the control plane is still up.
+#    The node drain needs a reachable workload API server.
+kubectl -n my-ns patch cluster my-cluster --type=merge \
+  -p '{"spec":{"topology":{"workers":{"machineDeployments":[{"class":"default-worker","name":"workers","replicas":0}]}}}}'
+# wait for the worker Machines/VMs to be deleted
+
+# 2. Pause CAPI reconciliation so CAPHV stops restarting the VMs.
+kubectl -n my-ns patch cluster my-cluster --type=merge -p '{"spec":{"paused":true}}'
+
+# 3. Halt the control-plane VM(s) on Harvester (disks are preserved).
+kubectl --kubeconfig <harvester-kubeconfig> -n <target-ns> patch vm <cp-vm-name> \
+  --type=merge -p '{"spec":{"runStrategy":"Halted"}}'
+```
+
+> **Do not scale the control plane to zero** — the RKE2ControlPlane webhook
+> rejects `replicas <= 0`. Halting the VM with the cluster paused achieves
+> the same effect.
+
+> **Ordering pitfall:** if you halt the control plane *before* the worker
+> scale-down finishes, the Machine deletion blocks on node drain (the
+> workload API server is unreachable). Recover with:
+> `kubectl -n my-ns annotate machine <worker-machine> \
+>    machine.cluster.x-k8s.io/exclude-node-draining=true \
+>    machine.cluster.x-k8s.io/exclude-wait-for-node-volume-detach=true`
+> A Machine stuck in `Deleting` while the cluster is paused will only
+> finalize after unpausing — or remove its finalizers manually once you
+> have confirmed the Harvester VM and PVC are gone.
+
+**Resume:**
+
+```bash
+# 1. Restart the control-plane VM and wait for the workload API server.
+kubectl --kubeconfig <harvester-kubeconfig> -n <target-ns> patch vm <cp-vm-name> \
+  --type=merge -p '{"spec":{"runStrategy":"Always"}}'
+
+# 2. Unpause; CAPHV reconciles from the existing state.
+kubectl -n my-ns patch cluster my-cluster --type=merge -p '{"spec":{"paused":false}}'
+
+# 3. Scale the workers back up (fresh VMs are provisioned, ~10 min each).
+kubectl -n my-ns patch cluster my-cluster --type=merge \
+  -p '{"spec":{"topology":{"workers":{"machineDeployments":[{"class":"default-worker","name":"workers","replicas":1}]}}}}'
+```
+
+Expect the control plane to report `Ready` a few minutes after the VM boots
+(RKE2 restart + etcd recovery), and `MachineHealthCheck` to hold off as long
+as `nodeStartupTimeout` allows.
+
 ---
 
 ## MachineHealthCheck and Auto-Remediation


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an operations runbook for parking a CAPHV cluster without deleting
it — keeping the VM disks on Harvester and the CAPI objects on the
management cluster so a resume takes minutes instead of a full
re-provision.

The new "Pausing and resuming a cluster" section in `docs/operations.md`
documents:
- Scaling workers to zero **before** halting the control plane (the node
  drain needs a reachable workload API server)
- `cluster.spec.paused` + KubeVirt `runStrategy: Halted/Always`
- The pitfall where the RKE2ControlPlane webhook rejects `replicas <= 0`
  (halt the VM with the cluster paused instead)
- Recovery for a Machine stuck in `Deleting` when the control plane was
  halted first (`exclude-node-draining` /
  `exclude-wait-for-node-volume-detach` annotations)
- Resume ordering and expected timings

Also removes a Prerequisites block in `README.md` that was accidentally
duplicated below the RKE2 CAPIProvider example during the v0.3.0 docs
update.

Documentation-only — no code changes.

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests (N/A — docs only)
- [ ] adds or updates e2e tests (N/A — docs only)