### PR TITLE
fix: add 0.3 release series (v1beta2 contract) to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 0
+    minor: 3
+    contract: v1beta2
+  - major: 0
     minor: 2
     contract: v1beta1
   - major: 0


### PR DESCRIPTION
**What this PR does / why we need it**:

`clusterctl` resolves a provider version to a CAPI contract via the
release's `metadata.yaml`. The `0.3` release series was never added, so:

```
clusterctl init --infrastructure harvester:v0.3.0
Error: invalid provider metadata: version v0.3.0 for the provider
caphv-system/infrastructure-harvester does not match any release series.
Available series: [0.2, 0.1]
```

This blocks every clusterctl-based install/upgrade of v0.3.0 — i.e. the
canonical way to run CAPHV on a management cluster without Rancher/Turtles.

v0.3.0 ships the **v1beta2** contract (CAPI v1.12), so this maps the `0.3`
series to `v1beta2`.

**Verified**: with this metadata, `clusterctl init --core cluster-api:v1.12.8
--bootstrap rke2:v0.25.0 --control-plane rke2:v0.25.0 --infrastructure
harvester:v0.3.0` brings up all four controllers (`1/1 Running`) and the
CAPHV webhook becomes Ready on a fresh cluster.

> Note: the `metadata.yaml` asset already attached to the v0.3.0 release is
> stale and will be refreshed separately so existing `clusterctl init
> harvester:v0.3.0` invocations resolve without an overrides workaround.

**Special notes for your reviewer**:
Trivial metadata addition; no code or manifest changes.

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation (metadata.yaml is the clusterctl contract map)
- [ ] adds unit tests (N/A)
- [ ] adds or updates e2e tests (N/A)
