### PR TITLE
docs: drop fork framing and personal repo leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cluster API Provider Harvester (CAPHV)
 
-> Fork of [rancher-sandbox/cluster-api-provider-harvester](https://github.com/rancher-sandbox/cluster-api-provider-harvester) with Harvester v1.7+/v1.8+ compatibility and production-ready features.
+> Kubernetes Cluster API infrastructure provider for [Harvester HCI](https://harvesterhci.io), with Harvester v1.7+/v1.8+ compatibility and production-ready features.
 
 ## Overview
 

--- a/caphv-quickstart.md
+++ b/caphv-quickstart.md
@@ -125,11 +125,11 @@ Sur notre Rancher Manager, Turtles a deja installe :
 # Build de l'image (depuis node1)
 cd /tmp/caphv
 podman build --build-arg TARGETARCH=amd64 . \
-  -t gitea.home.zypp.fr/jniedergang/cluster-api-provider-harvester:v0.2.0-rc11
+  -t ghcr.io/rancher-sandbox/cluster-api-provider-harvester:dev
 
 # Transferer l'image sur le management cluster (si pas de registry)
-podman save gitea.home.zypp.fr/jniedergang/cluster-api-provider-harvester:v0.2.0-rc11 \
-  | ssh rancher@172.16.3.20 'sudo /var/lib/rancher/rke2/bin/ctr \
+podman save ghcr.io/rancher-sandbox/cluster-api-provider-harvester:dev \
+  | ssh <user>@<management-node> 'sudo /var/lib/rancher/rke2/bin/ctr \
     --address /run/k3s/containerd/containerd.sock \
     --namespace k8s.io images import -'
 


### PR DESCRIPTION
Addresses the documentation nitpicks from the SURE-11421 review:

- `README.md`: the project no longer presents itself as a fork.
- `caphv-quickstart.md`: personal repository leftovers (`jniedergang` URLs) replaced with the canonical `rancher-sandbox` paths.
