### PR TITLE
feat: publish the Paused condition and deprecate terminal failure fields (v1beta2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ clusters would hang in provisioning.
   > `Cluster.status.initialization.infrastructureProvisioned` transitions to
   > `true` via the v1beta2 read path, and existing clusters are unaffected.
 
+- `HarvesterCluster` and `HarvesterMachine` now publish the `Paused` condition
+  (v1beta2 contract) whenever the owner `Cluster` or the object itself is
+  paused, and pausing freezes the object state instead of flipping
+  `HarvesterMachine.status.ready` to `false`. Pause/unpause transitions on the
+  `Cluster` trigger an immediate reconciliation (new watch); the
+  pause-filtering event predicates were removed accordingly.
+
+### Deprecated
+
+- `HarvesterCluster.status.failureReason`/`.failureMessage` and
+  `HarvesterMachine.status.failureReason`/`.failureMessage`: the CAPI v1beta2
+  contract removed terminal failures — failures surface through the
+  conditions instead. The controller no longer sets these fields; they will
+  be dropped at the next API version.
+
 ### Security
 
 - Bumped `go.opentelemetry.io/otel/sdk` to v1.43.0 (and `otel`/`otel/trace`),

--- a/api/v1alpha1/harvestercluster_types.go
+++ b/api/v1alpha1/harvestercluster_types.go
@@ -299,9 +299,17 @@ type HarvesterClusterStatus struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// FailureReason is the short name for the reason why a failure might be happening that makes the cluster not ready.
+	//
+	// Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+	// surface through the conditions. The controller no longer sets this field, which
+	// will be dropped at the next API version.
 	// +optional
 	FailureReason string `json:"failureReason,omitempty"`
 	// FailureMessage is a full error message dump of the above failureReason.
+	//
+	// Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+	// surface through the conditions. The controller no longer sets this field, which
+	// will be dropped at the next API version.
 	// +optional
 	FailureMessage string `json:"failureMessage,omitempty"`
 

--- a/api/v1alpha1/harvestermachine_types.go
+++ b/api/v1alpha1/harvestermachine_types.go
@@ -173,9 +173,22 @@ type HarvesterMachineStatus struct {
 
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	FailureReason  string                     `json:"failureReason,omitempty"`
-	FailureMessage string                     `json:"failureMessage,omitempty"`
-	Addresses      []clusterv1.MachineAddress `json:"addresses,omitempty"`
+	// FailureReason is the short name for the reason of a terminal failure.
+	//
+	// Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+	// surface through the conditions. The controller never sets this field, which
+	// will be dropped at the next API version.
+	// +optional
+	FailureReason string `json:"failureReason,omitempty"`
+	// FailureMessage is a full error message dump of the above failureReason.
+	//
+	// Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+	// surface through the conditions. The controller never sets this field, which
+	// will be dropped at the next API version.
+	// +optional
+	FailureMessage string `json:"failureMessage,omitempty"`
+
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 	// Initialization provides the CAPI v1beta2 contract readiness field
 	// (status.initialization.provisioned), kept in sync with status.ready (v1beta1 contract).
 	Initialization Initialization `json:"initialization,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_harvesterclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_harvesterclusters.yaml
@@ -355,12 +355,20 @@ spec:
                   type: object
                 type: array
               failureMessage:
-                description: FailureMessage is a full error message dump of the above
-                  failureReason.
+                description: |-
+                  FailureMessage is a full error message dump of the above failureReason.
+
+                  Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+                  surface through the conditions. The controller no longer sets this field, which
+                  will be dropped at the next API version.
                 type: string
               failureReason:
-                description: FailureReason is the short name for the reason why a
-                  failure might be happening that makes the cluster not ready.
+                description: |-
+                  FailureReason is the short name for the reason why a failure might be happening that makes the cluster not ready.
+
+                  Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+                  surface through the conditions. The controller no longer sets this field, which
+                  will be dropped at the next API version.
                 type: string
               initialization:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_harvestermachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_harvestermachines.yaml
@@ -789,8 +789,20 @@ spec:
                   type: object
                 type: array
               failureMessage:
+                description: |-
+                  FailureMessage is a full error message dump of the above failureReason.
+
+                  Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+                  surface through the conditions. The controller never sets this field, which
+                  will be dropped at the next API version.
                 type: string
               failureReason:
+                description: |-
+                  FailureReason is the short name for the reason of a terminal failure.
+
+                  Deprecated: the CAPI v1beta2 contract removed terminal failures; failures now
+                  surface through the conditions. The controller never sets this field, which
+                  will be dropped at the next API version.
                 type: string
               initialization:
                 description: |-

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -557,6 +557,10 @@ kubectl -n my-ns patch cluster my-cluster --type=merge \
 
 # 2. Pause CAPI reconciliation so CAPHV stops restarting the VMs.
 kubectl -n my-ns patch cluster my-cluster --type=merge -p '{"spec":{"paused":true}}'
+#    CAPHV acknowledges by setting condition Paused=True on the HarvesterCluster
+#    and HarvesterMachines (v1beta2 contract); their status is frozen until resume:
+kubectl -n my-ns get harvestercluster my-cluster \
+  -o jsonpath='{.status.conditions[?(@.type=="Paused")].status}'
 
 # 3. Halt the control-plane VM(s) on Harvester (disks are preserved).
 kubectl --kubeconfig <harvester-kubeconfig> -n <target-ns> patch vm <cp-vm-name> \

--- a/internal/controller/harvestercluster_controller.go
+++ b/internal/controller/harvestercluster_controller.go
@@ -57,6 +57,8 @@ import (
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
+	"sigs.k8s.io/cluster-api/util/predicates"
 
 	infrav1 "github.com/rancher-sandbox/cluster-api-provider-harvester/api/v1alpha1"
 	caphvmetrics "github.com/rancher-sandbox/cluster-api-provider-harvester/internal/metrics"
@@ -162,6 +164,13 @@ func (r *HarvesterClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
+	// Publish the Paused condition (v1beta2 contract) and freeze reconciliation while
+	// the Cluster or the HarvesterCluster is paused.
+	isPaused, requeuePaused, err := paused.EnsurePausedCondition(ctx, r.Client, clusterOwner, &cluster)
+	if err != nil || isPaused || requeuePaused {
+		return ctrl.Result{}, err
+	}
+
 	var hvRESTConfig *rest.Config
 
 	hvRESTConfig, err = r.reconcileHarvesterConfig(ctx, &cluster)
@@ -225,7 +234,29 @@ func (r *HarvesterClusterReconciler) SetupWithManager(ctx context.Context, mgr c
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSecret),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
+		// Pause/unpause transitions on the owner Cluster must trigger a reconciliation
+		// so the Paused condition (v1beta2 contract) is published on the HarvesterCluster.
+		Watches(
+			&clusterv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(clusterToHarvesterCluster),
+			builder.WithPredicates(predicates.ClusterPausedTransitions(mgr.GetScheme(), ctrl.LoggerFrom(ctx))),
+		).
 		Complete(r)
+}
+
+// clusterToHarvesterCluster maps a CAPI Cluster to its referenced HarvesterCluster.
+// The v1beta2 infrastructure reference carries no namespace: it is always in the
+// Cluster's own namespace.
+func clusterToHarvesterCluster(_ context.Context, o client.Object) []ctrl.Request {
+	cluster, ok := o.(*clusterv1.Cluster)
+	if !ok || cluster.Spec.InfrastructureRef.Kind != "HarvesterCluster" || cluster.Spec.InfrastructureRef.Name == "" {
+		return nil
+	}
+
+	return []ctrl.Request{{NamespacedName: types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Spec.InfrastructureRef.Name,
+	}}}
 }
 
 // ReconcileNormal is the reconciliation function when not deleting the HarvesterCluster instance.
@@ -1228,8 +1259,6 @@ func (r *HarvesterClusterReconciler) reconcileHarvesterConfig(ctx context.Contex
 
 	secret, err := locutil.GetSecretForHarvesterConfig(ctx, cluster, r.Client)
 	if (err != nil || secret == &apiv1.Secret{}) {
-		cluster.Status.FailureReason = "IdentitySecretUnavailable"
-		cluster.Status.FailureMessage = "unable to find the IdentitySecret for Harvester"
 		cluster.Status.Ready = false
 
 		conditions.Set(cluster, v1.Condition{
@@ -1246,8 +1275,6 @@ func (r *HarvesterClusterReconciler) reconcileHarvesterConfig(ctx context.Contex
 
 	harvesterServer, err := getHarvesterServerFromKubeconfig(kubeconfig)
 	if err != nil {
-		cluster.Status.FailureReason = "MalformedIdentitySecret"
-		cluster.Status.FailureMessage = err.Error()
 		cluster.Status.Ready = false
 
 		conditions.Set(cluster, v1.Condition{

--- a/internal/controller/harvestermachine_controller.go
+++ b/internal/controller/harvestermachine_controller.go
@@ -48,9 +48,9 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/cluster-api/util/predicates"
 
 	infrav1 "github.com/rancher-sandbox/cluster-api-provider-harvester/api/v1alpha1"
@@ -176,6 +176,14 @@ func (r *HarvesterMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	logger = logger.WithValues("machine", ownerMachine.Namespace+"/"+ownerMachine.Name, "cluster", ownerCluster.Namespace+"/"+ownerCluster.Name)
 	ctx = ctrl.LoggerInto(ctx, logger)
 
+	// Publish the Paused condition (v1beta2 contract) and freeze reconciliation while
+	// the Cluster or the HarvesterMachine is paused. Placed before any Harvester access
+	// so a paused object never triggers infrastructure calls.
+	isPaused, requeuePaused, err := paused.EnsurePausedCondition(ctx, r.Client, ownerCluster, hvMachine)
+	if err != nil || isPaused || requeuePaused {
+		return ctrl.Result{}, err
+	}
+
 	hvCluster := &infrav1.HarvesterCluster{}
 
 	// CAPI v1beta2 ContractVersionedObjectReference dropped the Namespace field —
@@ -231,15 +239,16 @@ func (r *HarvesterMachineReconciler) SetupWithManager(ctx context.Context, mgr c
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.HarvesterMachine{}).
+		// No pause-filtering predicates: pause/unpause transitions must reach the
+		// reconciler so the Paused condition (v1beta2 contract) is published.
 		Watches(
 			&clusterv1.Machine{},
 			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1.GroupVersion.WithKind("HarvesterMachine"))),
-			builder.WithPredicates(predicates.ResourceNotPaused(mgr.GetScheme(), ctrl.LoggerFrom(ctx))),
 		).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToHarvesterMachine),
-			builder.WithPredicates(predicates.ClusterUnpaused(mgr.GetScheme(), ctrl.LoggerFrom(ctx))),
+			builder.WithPredicates(predicates.ClusterPausedTransitions(mgr.GetScheme(), ctrl.LoggerFrom(ctx))),
 		).
 		Complete(r)
 }
@@ -264,16 +273,6 @@ func (r *HarvesterMachineReconciler) ReconcileNormal(hvScope *Scope) (res reconc
 	}()
 
 	logger := log.FromContext(hvScope.Ctx)
-
-	// Return early if the object or Cluster is paused.
-	if annotations.IsPaused(hvScope.Cluster, hvScope.HarvesterMachine) {
-		logger.Info("Reconciliation is paused for this object")
-
-		hvScope.HarvesterMachine.Status.Ready = false
-		hvScope.HarvesterMachine.Status.Initialization = machineInitializationNotProvisioned
-
-		return ctrl.Result{}, nil
-	}
 
 	// Migrate legacy finalizer: if the object has the old finalizer but not the new one, swap them.
 	if controllerutil.ContainsFinalizer(hvScope.HarvesterMachine, infrav1.MachineFinalizerLegacy) &&

--- a/internal/controller/paused_condition_test.go
+++ b/internal/controller/paused_condition_test.go
@@ -1,0 +1,195 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+	infrav1 "github.com/rancher-sandbox/cluster-api-provider-harvester/api/v1alpha1"
+)
+
+func pausedTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(infrav1.AddToScheme(scheme)).To(Succeed())
+	Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	return scheme
+}
+
+func pausedTestCluster(paused bool) *clusterv1.Cluster {
+	return &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner-cluster", Namespace: "default"},
+		Spec: clusterv1.ClusterSpec{
+			Paused: ptr.To(paused),
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: infrav1.GroupVersion.Group,
+				Kind:     "HarvesterCluster",
+				Name:     "hv-cluster",
+			},
+		},
+	}
+}
+
+func ownedHarvesterCluster() *infrav1.HarvesterCluster {
+	return &infrav1.HarvesterCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hv-cluster",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Cluster",
+				Name:       "owner-cluster",
+				UID:        types.UID("owner-cluster-uid"),
+			}},
+		},
+	}
+}
+
+var _ = Describe("Paused condition on HarvesterCluster (v1beta2 contract)", func() {
+	newReconciler := func(objs ...client.Object) *HarvesterClusterReconciler {
+		scheme := pausedTestScheme()
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(&infrav1.HarvesterCluster{}).
+			Build()
+
+		return &HarvesterClusterReconciler{Client: cl, Scheme: scheme}
+	}
+
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Name: "hv-cluster", Namespace: "default"}}
+
+	It("sets Paused=True and skips reconciliation when the owner Cluster is paused", func(ctx SpecContext) {
+		reconciler := newReconciler(pausedTestCluster(true), ownedHarvesterCluster())
+
+		_, err := reconciler.Reconcile(ctx, request)
+		Expect(err).ToNot(HaveOccurred())
+
+		hvCluster := &infrav1.HarvesterCluster{}
+		Expect(reconciler.Get(ctx, request.NamespacedName, hvCluster)).To(Succeed())
+
+		Expect(meta.IsStatusConditionTrue(hvCluster.Status.Conditions, clusterv1.PausedCondition)).
+			To(BeTrue(), "Paused condition must be True, conditions: %v", hvCluster.Status.Conditions)
+		// Reconciliation must stop before touching Harvester: no connection condition.
+		Expect(meta.FindStatusCondition(hvCluster.Status.Conditions, infrav1.HarvesterConnectionReadyCondition)).
+			To(BeNil(), "reconciliation must not proceed while paused")
+	})
+
+	It("sets Paused=False and proceeds when the owner Cluster is not paused", func(ctx SpecContext) {
+		reconciler := newReconciler(pausedTestCluster(false), ownedHarvesterCluster())
+
+		// The reconciliation proceeds and fails further down (no identity secret): the
+		// error is expected, only the Paused condition matters here.
+		_, _ = reconciler.Reconcile(ctx, request)
+
+		hvCluster := &infrav1.HarvesterCluster{}
+		Expect(reconciler.Get(ctx, request.NamespacedName, hvCluster)).To(Succeed())
+
+		pausedCondition := meta.FindStatusCondition(hvCluster.Status.Conditions, clusterv1.PausedCondition)
+		Expect(pausedCondition).ToNot(BeNil(), "Paused condition must be present, conditions: %v", hvCluster.Status.Conditions)
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
+	})
+})
+
+var _ = Describe("Paused condition on HarvesterMachine (v1beta2 contract)", func() {
+	newReconciler := func(objs ...client.Object) *HarvesterMachineReconciler {
+		scheme := pausedTestScheme()
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(&infrav1.HarvesterMachine{}).
+			Build()
+
+		return &HarvesterMachineReconciler{Client: cl, Scheme: scheme}
+	}
+
+	ownerMachine := func() *clusterv1.Machine {
+		return &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "owner-machine",
+				Namespace: "default",
+				Labels:    map[string]string{clusterv1.ClusterNameLabel: "owner-cluster"},
+			},
+			Spec: clusterv1.MachineSpec{ClusterName: "owner-cluster"},
+		}
+	}
+
+	ownedHarvesterMachine := func() *infrav1.HarvesterMachine {
+		return &infrav1.HarvesterMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hv-machine",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "Machine",
+					Name:       "owner-machine",
+					UID:        types.UID("owner-machine-uid"),
+				}},
+			},
+		}
+	}
+
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Name: "hv-machine", Namespace: "default"}}
+
+	It("sets Paused=True and returns before fetching the HarvesterCluster when the owner Cluster is paused", func(ctx SpecContext) {
+		// No HarvesterCluster object exists: if the paused check ran after the
+		// HarvesterCluster lookup, the reconciliation would error out.
+		reconciler := newReconciler(pausedTestCluster(true), ownerMachine(), ownedHarvesterMachine())
+
+		_, err := reconciler.Reconcile(ctx, request)
+		Expect(err).ToNot(HaveOccurred())
+
+		hvMachine := &infrav1.HarvesterMachine{}
+		Expect(reconciler.Get(ctx, request.NamespacedName, hvMachine)).To(Succeed())
+
+		Expect(meta.IsStatusConditionTrue(hvMachine.Status.Conditions, clusterv1.PausedCondition)).
+			To(BeTrue(), "Paused condition must be True, conditions: %v", hvMachine.Status.Conditions)
+	})
+
+	It("sets Paused=False when the owner Cluster is not paused", func(ctx SpecContext) {
+		// Reconciliation proceeds and fails on the missing HarvesterCluster: the error
+		// is expected, only the Paused condition matters here.
+		reconciler := newReconciler(pausedTestCluster(false), ownerMachine(), ownedHarvesterMachine())
+
+		_, _ = reconciler.Reconcile(ctx, request)
+
+		hvMachine := &infrav1.HarvesterMachine{}
+		Expect(reconciler.Get(ctx, request.NamespacedName, hvMachine)).To(Succeed())
+
+		pausedCondition := meta.FindStatusCondition(hvMachine.Status.Conditions, clusterv1.PausedCondition)
+		Expect(pausedCondition).ToNot(BeNil(), "Paused condition must be present, conditions: %v", hvMachine.Status.Conditions)
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
+	})
+})
+
+var _ = Describe("Deprecated terminal failure fields (v1beta2 contract)", func() {
+	It("does not write FailureReason/FailureMessage when the identity secret is missing", func(ctx SpecContext) {
+		scheme := pausedTestScheme()
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		reconciler := &HarvesterClusterReconciler{Client: cl, Scheme: scheme}
+
+		hvCluster := ownedHarvesterCluster()
+		_, err := reconciler.reconcileHarvesterConfig(ctx, hvCluster)
+		Expect(err).To(HaveOccurred(), "the identity secret is missing")
+
+		// v1beta2 removed terminal failures: the error must surface through the
+		// HarvesterConnectionReady condition only, not the deprecated fields.
+		Expect(hvCluster.Status.FailureReason).To(BeEmpty())  //nolint:staticcheck // asserting the deprecated field stays empty
+		Expect(hvCluster.Status.FailureMessage).To(BeEmpty()) //nolint:staticcheck // asserting the deprecated field stays empty
+		Expect(meta.IsStatusConditionFalse(hvCluster.Status.Conditions, infrav1.HarvesterConnectionReadyCondition)).
+			To(BeTrue(), "the failure must surface via the connection condition")
+	})
+})


### PR DESCRIPTION
Follow-up of #202, completing the v1beta2 contract on the publish side.

### Paused condition

`HarvesterCluster` and `HarvesterMachine` now publish the `Paused` condition through
`paused.EnsurePausedCondition`, placed before any Harvester access so a paused object
never triggers infrastructure calls. Pausing freezes the object state instead of
flipping `HarvesterMachine.status.ready` to `false`.

Event plumbing had to change accordingly: the old pause-filtering predicates
(`ResourceNotPaused`, `ClusterUnpaused`) swallowed the very events the condition must
react to. They are removed, the HarvesterCluster controller gains a `Cluster` watch,
and both controllers now use `ClusterPausedTransitions`, so pause/unpause transitions
trigger an immediate reconciliation.

### Deprecated terminal failure fields

`status.failureReason`/`status.failureMessage` on both objects are deprecated and no
longer written: the v1beta2 contract removed terminal failures, and both write sites
already surfaced the error through the `HarvesterConnectionReady` condition. The fields
will be dropped at the next API version.

### Validation

- Unit tests (fake-client reconciles): Paused=True freezes reconciliation before any
  Harvester access, Paused=False lets it proceed, failure fields stay empty on identity
  secret errors.
- Functional run on kind (CAPI core v1.12.7 via cluster-api-operator, controller built
  from this branch): initial `Paused=False` on adoption, `Paused=True` on
  `Cluster.spec.paused=true` **via the transition watch alone**, back to `False` on
  unpause; `failureReason` stays empty while the error surfaces through
  `HarvesterConnectionReady`.
- CHANGELOG and the pause/resume runbook updated.
