### PR TITLE
test(cert)+docs: certify v0.4.0 by default and document the release process

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,32 @@
+# Release process
+
+Checklist for cutting a CAPHV release (`vX.Y.Z`).
+
+## Before tagging
+
+1. **CHANGELOG.md** — turn `[Unreleased]` into `[vX.Y.Z] - YYYY-MM-DD`.
+2. **metadata.yaml** — on a new *minor* series only: add the `major/minor` entry with
+   its CAPI contract version (clusterctl refuses to install a version missing from the
+   release series).
+3. Land the above through a PR (DCO sign-off required), then tag the merge commit:
+
+   ```bash
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+## Release workflow
+
+The `release.yml` workflow triggers on the tag and produces: the multi-arch image on
+GHCR, the Helm OCI chart, `infrastructure-components.yaml` + `metadata.yaml` +
+cluster templates as release assets, cosign signatures (verify with **cosign v3+**:
+v2 wrongly reports "no signatures" on OCI 1.1 bundles) and build provenance.
+
+## After the release is published
+
+1. **Certification defaults** — bump `CAPHV_VERSION` and `CAPHV_COMPONENTS_URL` in
+   `test/certification/config/config.yaml` so the nightly certifies the new release
+   (only after the assets exist, otherwise the nightly fails on the download URL).
+2. Spot-check the assets: the `infrastructure-components.yaml` URL resolves and
+   references the `vX.Y.Z` image.
+3. Optionally trigger the on-demand `certification-tier-a` workflow against the new
+   version.

--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -26,8 +26,8 @@ variables:
 
   # Version pairing under certification: the CAPHV release below is certified against the
   # targeted CAPI core. Override via environment (CI does) to certify other pairings.
-  CAPHV_VERSION: "v0.3.1"
-  CAPHV_COMPONENTS_URL: "https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.3.1/infrastructure-components.yaml"
+  CAPHV_VERSION: "v0.4.0"
+  CAPHV_COMPONENTS_URL: "https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.4.0/infrastructure-components.yaml"
   CAPI_VERSION: "v1.12.7"
 
   # cluster-api-operator chart (Rancher-independent provider lifecycle manager).


### PR DESCRIPTION
Bumps the certification defaults to the freshly released v0.4.0 (assets verified) and adds a short release checklist (docs/release-process.md) covering the release-series metadata and this certification bump — the two easy-to-forget steps.