### PR TITLE
docs: changelog and metadata for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 This fork diverges from [upstream](https://github.com/rancher-sandbox/cluster-api-provider-harvester) v0.1.6 with Harvester v1.7.1 compatibility and production-ready features.
 
-## [Unreleased]
+## [v0.5.0] - 2026-07-06
 
 ### Added — API graduation to v1beta1
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 0
+    minor: 5
+    contract: v1beta2
+  - major: 0
     minor: 4
     contract: v1beta2
   - major: 0


### PR DESCRIPTION
Adds the 0.5 release series (v1beta2 contract) to `metadata.yaml` and freezes the changelog for v0.5.0 (API graduation to v1beta1, #206). Tag `v0.5.0` follows once merged.