### PR TITLE
test(cert): certify v0.5.0 by default

### DIFF
--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -26,8 +26,8 @@ variables:
 
   # Version pairing under certification: the CAPHV release below is certified against the
   # targeted CAPI core. Override via environment (CI does) to certify other pairings.
-  CAPHV_VERSION: "v0.4.0"
-  CAPHV_COMPONENTS_URL: "https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.4.0/infrastructure-components.yaml"
+  CAPHV_VERSION: "v0.5.0"
+  CAPHV_COMPONENTS_URL: "https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.5.0/infrastructure-components.yaml"
   CAPI_VERSION: "v1.12.7"
 
   # cluster-api-operator chart (Rancher-independent provider lifecycle manager).


### PR DESCRIPTION
Bumps the certification defaults to the freshly released v0.5.0 (assets verified), per docs/release-process.md.