### PR TITLE
fix: keep the CAPI contract labels out of the workload selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 
 This fork diverges from [upstream](https://github.com/rancher-sandbox/cluster-api-provider-harvester) v0.1.6 with Harvester v1.7.1 compatibility and production-ready features.
 
+## [Unreleased]
+
+### Fixed
+
+- The CAPI contract labels are no longer part of the controller Deployment and
+  Service selectors (`includeSelectors: false`): selectors are immutable, so every
+  contract-label change used to break `kubectl apply` upgrades (and could leave the
+  webhook Service without endpoints). Selectors are now the minimal
+  `control-plane: controller-manager` and will stay stable across releases.
+  **One-time upgrade note**: applying these manifests over an existing install with
+  `kubectl apply` requires deleting the controller Deployment once
+  (`kubectl -n caphv-system delete deploy caphv-controller-manager`) before applying;
+  `clusterctl`/CAPI-operator-managed installs are unaffected.
+
 ## [v0.5.0] - 2026-07-06
 
 ### Added — API graduation to v1beta1

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -133,5 +133,5 @@ labels:
     cluster.x-k8s.io/v1beta1: v1alpha1
     cluster.x-k8s.io/v1alpha2: v1alpha1
     cluster.x-k8s.io/v1alpha3: v1alpha1
-  includeSelectors: true
+  includeSelectors: false
   includeTemplates: true


### PR DESCRIPTION
Selectors are immutable: every contract-label change used to break `kubectl apply` upgrades on the controller Deployment — and a half-applied upgrade left the webhook Service selector pointing at labels the running pods did not have (no endpoints, conversion dead; observed on a real management cluster during the v0.5.0 gate).

This switches the kustomize `labels` directive to `includeSelectors: false`: Deployment/Service selectors are now the minimal `control-plane: controller-manager` and stay stable across releases, while the CRDs keep the contract labels (where contract discovery reads them) and every object keeps the `cluster.x-k8s.io/provider` label (clusterctl move).

**One-time upgrade note** (in the changelog): applying these manifests over an existing install with `kubectl apply` requires deleting the controller Deployment once; clusterctl/CAPI-operator-managed installs are unaffected.

Validated on kind with a fresh install from these manifests: webhook endpoints up, v1alpha1↔v1beta1 conversion and the Paused-condition behavior nominal.