### PR TITLE
test: add the Turtles integration suite (CreateUsingGitOpsSpec) + manifest/RBAC fixes

### DIFF
--- a/.github/workflows/certification-import-gitops.yml
+++ b/.github/workflows/certification-import-gitops.yml
@@ -1,0 +1,58 @@
+# Turtles integration suite (CreateUsingGitOpsSpec) against a real Harvester.
+#
+# Runs on a self-hosted runner living inside the test environment (a VM with
+# docker, kind, helm, go and network reach to the Harvester cluster and to the
+# workload VMs it provisions) — same pattern as rancher/rancher-turtles-e2e's
+# vSphere runner. The job is therefore guarded to the repository that owns the
+# runner; it never runs on pull requests.
+name: certification-import-gitops
+
+on:
+  schedule:
+    - cron: "0 3 * * 1,4"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  turtles-integration:
+    if: github.repository_owner == 'jniedergang'
+    runs-on: [self-hosted, harvester]
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+
+      - name: Build the suite
+        working-directory: test/certification
+        run: |
+          mkdir -p _artifacts
+          GOTOOLCHAIN=auto go test -c -tags e2e -o bin/import-gitops.test ./suites/import-gitops/
+
+      - name: Run the Turtles integration suite
+        working-directory: test/certification
+        env:
+          HARVESTER_KUBECONFIG_B64: ${{ secrets.HARVESTER_KUBECONFIG_B64 }}
+        run: |
+          # The Rancher server-url must be reachable both from inside the kind
+          # cluster and from the workload VMs: the runner VM's LAN IP is.
+          RANCHER_HOSTNAME="$(hostname -I | awk '{print $1}').sslip.io"
+          sudo env "PATH=/root/.krew/bin:/usr/local/bin:$PATH" HOME=/root GOTOOLCHAIN=auto \
+            E2E_CONFIG="$PWD/config/config.yaml" ARTIFACTS_FOLDER="$PWD/_artifacts" \
+            HELM_BINARY_PATH=/usr/local/bin/helm HELM_EXTRA_VALUES_FOLDER="$PWD/_artifacts" \
+            MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind \
+            RANCHER_HOSTNAME="$RANCHER_HOSTNAME" \
+            HARVESTER_KUBECONFIG_B64="$HARVESTER_KUBECONFIG_B64" \
+            ./bin/import-gitops.test -test.timeout 140m -test.v -ginkgo.v
+
+      - name: Collect artifacts
+        if: always()
+        working-directory: test/certification
+        run: sudo chown -R "$(id -u):$(id -g)" _artifacts || true
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v4
+        if: always()
+        with:
+          name: import-gitops-artifacts
+          path: test/certification/_artifacts
+          retention-days: 14

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -61,8 +61,6 @@ replacements:
       index: 0
   - select:
       kind: CustomResourceDefinition
-    reject:
-    - name: harvesterclustertemplates.infrastructure.cluster.x-k8s.io
     fieldPaths:
     - metadata.annotations.[cert-manager.io/inject-ca-from]
     options:
@@ -84,8 +82,6 @@ replacements:
       index: 1
   - select:
       kind: CustomResourceDefinition
-    reject:
-    - name: harvesterclustertemplates.infrastructure.cluster.x-k8s.io
     fieldPaths:
     - metadata.annotations.[cert-manager.io/inject-ca-from]
     options:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,3 +79,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - provisioning.cattle.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,26 @@
+# Compatibility matrix
+
+Rancher drives the CAPI core version (through the Turtles system chart), and the CAPI
+core version determines which provider contract is exercised — this matrix records
+which CAPHV release works with what, and how each pairing is validated.
+
+| CAPHV | Provider API | CAPI contract published | CAPI core | Rancher / Turtles | Validation |
+|-------|--------------|-------------------------|-----------|-------------------|------------|
+| v0.5.x | `v1beta1` (`v1alpha1` served, deprecated) | v1beta1 + v1beta2 | v1.12.x | Rancher 2.14.x / Turtles 0.26.x | nightly version-pairing (CAPI v1.12.7), Rancher-stack suite (2.14.1, Turtles 109.0.1+up0.26.1, core v1.12.2), Turtles integration suite on real Harvester |
+| v0.4.x | `v1alpha1` | v1beta1 + v1beta2 | v1.12.x | Rancher 2.14.x / Turtles 0.26.x | nightly version-pairing, real-Harvester runs |
+| v0.3.x | `v1alpha1` | v1beta1 | v1.12.x | Rancher 2.13–2.14 / Turtles 0.25–0.26 | real-Harvester runs (homelab) |
+| v0.2.x | `v1alpha1` | v1beta1 | v1.10.x | Rancher 2.13.x / Turtles 0.25.x | Turtles integration suite (turtles/test v0.25.4, full lifecycle) |
+
+Notes:
+
+- **Contract vs API**: the contract labels on the CRDs (`cluster.x-k8s.io/v1beta1`,
+  `v1beta2`) tell the CAPI core how to read the provider objects; the provider API
+  version (`v1alpha1`/`v1beta1`) is the schema users write. They evolve independently.
+- Turtles pins provider versions only for Rancher Prime (see the SUSE Prime
+  documentation); with community Rancher, install CAPHV through a `CAPIProvider` with an
+  explicit `version` and `fetchConfig` URL.
+- Harvester side: validated against Harvester 1.8.x (VM provisioning, IP pools,
+  multi-NIC). Older 1.6/1.7 pairings were exercised by the v0.2.x runs.
+- The suites behind the "Validation" column live in `test/certification/` and run in CI
+  (`certification.yml` nightly, `certification-tier-a.yml` and the integration suite on
+  demand).

--- a/internal/controller/harvestercluster_controller.go
+++ b/internal/controller/harvestercluster_controller.go
@@ -104,6 +104,8 @@ type ClusterScope struct {
 	ReconcileClient  client.Client
 }
 
+//+kubebuilder:rbac:groups=provisioning.cattle.io,resources=clusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=provisioning.cattle.io,resources=clusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=harvesterclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=harvesterclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=harvesterclusters/finalizers,verbs=update

--- a/test/certification/Makefile
+++ b/test/certification/Makefile
@@ -43,3 +43,15 @@ clean: ## Clean artifacts
 .PHONY: help
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: test-import-gitops
+test-import-gitops: ## Run the Turtles integration suite (full lifecycle on a real Harvester; needs RANCHER_HOSTNAME + HARVESTER_KUBECONFIG_B64)
+	mkdir -p $(ARTIFACTS_FOLDER)
+	E2E_CONFIG=$(E2E_CONFIG) \
+	ARTIFACTS_FOLDER=$(ARTIFACTS_FOLDER) \
+	HELM_BINARY_PATH=$(HELM_BINARY_PATH) \
+	HELM_EXTRA_VALUES_FOLDER=$(ARTIFACTS_FOLDER) \
+	MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind \
+	go test -v -tags e2e -timeout 120m -count 1 \
+		./suites/import-gitops/ \
+		-ginkgo.v

--- a/test/certification/README.md
+++ b/test/certification/README.md
@@ -7,8 +7,16 @@ run on standard CI runners:
 
 | Tier | Suite | Stack | Trigger |
 |------|-------|-------|---------|
+| **Turtles integration** (the suite the Turtles team expects) | `suites/import-gitops/` | Full Rancher + Turtles + real Harvester: `CreateUsingGitOpsSpec` provisions a cluster, verifies Available, the Rancher auto-import (cattle-cluster-agent) and a clean deletion | self-hosted runner (needs a Harvester) |
 | **Version-pairing** (nightly) | `suites/version-pairing/` | CAPI core + RKE2 via [cluster-api-operator] — no Rancher | `certification.yml` (nightly + dispatch) |
-| **Rancher + Turtles** (on-demand) | `suites/rancher-turtles/` | Full released Rancher; Turtles/CAPI/RKE2 via its system chart controller | `certification-tier-a.yml` (dispatch) |
+| **Rancher + Turtles stack** (on-demand) | `suites/rancher-turtles/` | Full released Rancher; Turtles/CAPI/RKE2 via its system chart controller — no workload cluster | `certification-tier-a.yml` (dispatch) |
+
+> Terminology: Turtles has no provider *certification* process — "certified" means
+> "actively tested". The integration tier is the flow the Turtles team maintains in
+> [rancher/turtles-integration-suite-example]; the other two tiers are lighter
+> complements. Version pairings are recorded in [docs/compatibility.md](../../docs/compatibility.md).
+
+[rancher/turtles-integration-suite-example]: https://github.com/rancher/turtles-integration-suite-example
 
 > Why is the nightly tier Rancher-free? Turtles 0.26+ cannot run standalone: its
 > controller watches Rancher's `management.cattle.io` CRDs and crashloops without a full
@@ -151,3 +159,24 @@ test/certification/
 After the suite passes for a new pairing, a certification issue can be submitted on
 [rancher/turtles](https://github.com/rancher/turtles/issues) with the test logs, the
 CAPHV version and a link to this suite.
+
+## Tier: Turtles integration (import-gitops)
+
+Runs `CreateUsingGitOpsSpec` against a **real Harvester**: kind management cluster with
+host port mappings (`MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind`), full Rancher from
+its official chart, Turtles + CAPI core via Rancher's system chart controller, RKE2 and
+CAPHV as `CAPIProvider`s, then the full lifecycle: provision from the ClusterClass
+template → cluster Available → Rancher auto-import verified downstream → deletion
+without stalling.
+
+Environment-specific inputs (never committed): `RANCHER_HOSTNAME` must resolve to a
+host IP reachable **from the workload VMs** (e.g. `<host-lan-ip>.sslip.io`, ports 80/443
+open), and `HARVESTER_KUBECONFIG_B64`. Install crust-gather first
+(`scripts/ensure-crust-gather.sh`) so the framework collects management and downstream
+state into `_artifacts/` automatically.
+
+```bash
+export RANCHER_HOSTNAME=<host-lan-ip>.sslip.io
+export HARVESTER_KUBECONFIG_B64=$(base64 -w0 < harvester.kubeconfig)
+make test-import-gitops
+```

--- a/test/certification/README.md
+++ b/test/certification/README.md
@@ -69,6 +69,43 @@ recorded in the logs.
 Run with `make test-tier-a` (or `make certification-test-tier-a` from the project root),
 overriding `RANCHER_VERSION` / `CAPHV_VERSION` as needed. Budget ~30-45 minutes.
 
+## Tier: Turtles integration suite (primary, scheduled)
+
+`suites/import-gitops/` runs the Turtles `CreateUsingGitOpsSpec` — the suite the
+Turtles team runs for every certified provider (modeled on
+`rancher/turtles-integration-suite-example`) — against a **real Harvester**:
+
+1. kind + cert-manager + nginx (hostPort) + released Rancher + Turtles + CAPI core,
+   plus the RKE2 providers and the CAPHV `CAPIProvider`;
+2. a ClusterClass-based RKE2 cluster (1 CP + 1 worker) is provisioned on Harvester
+   through GitOps (Fleet), with a pool-backed control-plane LoadBalancer;
+3. the cluster becomes `Available`, Rancher auto-imports it (cattle-cluster-agent
+   deployed downstream and connected), the v3 cluster record turns ready;
+4. the CAPI cluster is deleted and the suite verifies the deletion completes and the
+   Rancher record disappears (no stalling finalizers, VMs/LB/IPs released).
+
+**Environment requirements** (see also the workflow
+`.github/workflows/certification-import-gitops.yml`): a Linux host with **docker**
+(kind's mainstream provider), `kind`, `helm`, `kubectl`, `go` and the `crust-gather`
+kubectl plugin (`scripts/ensure-crust-gather.sh`), plus two network properties:
+
+- `RANCHER_HOSTNAME` (e.g. `<host-LAN-IP>.sslip.io`) must be reachable on 443 both
+  from inside the kind cluster and **from the workload VMs** Harvester provisions;
+- the host must reach the Harvester API and the workload cluster's control-plane
+  endpoint (an IP from the Harvester LB pool).
+
+A plain VM on the LAN satisfies both. Rootless/NAT'd container engines on multi-bridge
+hosts often do not — nested kind networking is the first thing to check when the
+downstream agent cannot reach the server-url.
+
+In CI the suite runs on a **self-hosted runner** living inside the test environment
+(same pattern as the Turtles vSphere runner), on a schedule and manual dispatch only —
+never on pull requests. `HARVESTER_KUBECONFIG_B64` is provided as an Actions secret.
+
+Run manually with `MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind`,
+`RANCHER_HOSTNAME=<host-ip>.sslip.io` and `HARVESTER_KUBECONFIG_B64=$(base64 -w0 <
+kubeconfig)`; budget ~40 minutes (see the workflow for the full invocation).
+
 ## Version matrix
 
 All pins live in `config/config.yaml` (`variables:`) and are overridable from the

--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -11,7 +11,12 @@ providers: []
 
 intervals:
   default/wait-controllers: ["10m", "10s"]
-  default/wait-rancher: ["15m", "30s"]
+  default/wait-rancher: ["30m", "30s"]
+  default/wait-cluster: ["30m", "30s"]
+  default/wait-delete-cluster: ["30m", "30s"]
+  default/wait-kubeconfig: ["10m", "30s"]
+  default/wait-gitpush: ["3m", "10s"]
+  default/wait-consistently: ["30s", "5s"]
 
 variables:
   # Management cluster: self-provisioned kind, no pre-existing cluster (version-pairing
@@ -52,3 +57,27 @@ variables:
   RANCHER_PATH: "rancher-latest/rancher"
   RANCHER_HOSTNAME: "localhost"
   RANCHER_PASSWORD: "rancherpassword"
+
+  # Import-gitops tier only (full lifecycle on a real Harvester): the suite runs with
+  # MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind and needs RANCHER_HOSTNAME resolving to
+  # a host IP reachable from the workload VMs (e.g. <host-lan-ip>.sslip.io), plus
+  # HARVESTER_KUBECONFIG_B64 — both are environment-specific and supplied by the wrapper
+  # or CI, never committed here.
+  NAMESPACE: "default"
+  KUBERNETES_VERSION: "v1.31.14"
+  RKE2_VERSION: "v1.31.14+rke2r1"
+  HARVESTER_KUBECONFIG_B64: ""
+  IDENTITY_SECRET_NAME: "hv-identity-secret"
+  TARGET_NAMESPACE: "default"
+  SSH_KEYPAIR: "default/capi-ssh-key"
+  SSH_USER: "sles"
+  VM_NETWORK: "default/production"
+  VOLUME_IMAGE: "default/sles15-sp7-minimal-vm.x86_64-cloud-qu2.qcow2"
+  VOLUME_SIZE: "40Gi"
+  CPU_COUNT: "2"
+  MEMORY_SIZE: "4Gi"
+  GATEWAY: "172.16.0.1"
+  SUBNET_MASK: "255.255.0.0"
+  IP_POOL_REF: "capi-vm-pool"
+  DNS_SERVERS: "172.16.0.1"
+  CNI: "calico"

--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -25,6 +25,7 @@ variables:
   # and export it.
   MANAGEMENT_CLUSTER_ENVIRONMENT: "isolated-kind"
   USE_EXISTING_CLUSTER: "false"
+  KUBERNETES_MANAGEMENT_VERSION: "v1.35.0"
   ARTIFACTS_FOLDER: "_artifacts"
   SKIP_RESOURCE_CLEANUP: "false"
   SKIP_DELETION_TEST: "false"

--- a/test/certification/scripts/ensure-crust-gather.sh
+++ b/test/certification/scripts/ensure-crust-gather.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Installe krew + le plugin kubectl crust-gather : le framework turtles/test collecte
+# alors automatiquement l'état des clusters (management + downstream) en artefacts.
+set -euo pipefail
+
+if kubectl crust-gather --version >/dev/null 2>&1; then
+  echo "crust-gather déjà installé"
+  exit 0
+fi
+
+if ! kubectl krew version >/dev/null 2>&1; then
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  OS="$(uname | tr '[:upper:]' '[:lower:]')"
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
+  KREW="krew-${OS}_${ARCH}"
+  curl -fsSLo "$TMP/${KREW}.tar.gz" "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz"
+  tar -C "$TMP" -zxf "$TMP/${KREW}.tar.gz"
+  "$TMP/${KREW}" install krew
+  echo 'Ajouter au PATH : export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"'
+fi
+
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+kubectl krew install crust-gather
+kubectl crust-gather --version

--- a/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
+++ b/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   controlPlane:
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: RKE2ControlPlaneTemplate
       name: ${CLUSTER_CLASS_NAME}-control-plane
     machineInfrastructure:
@@ -29,7 +29,7 @@ spec:
         template:
           bootstrap:
             ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
               kind: RKE2ConfigTemplate
               name: ${CLUSTER_CLASS_NAME}-worker
           infrastructure:
@@ -335,7 +335,7 @@ spec:
     - name: cni
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true
@@ -355,7 +355,7 @@ spec:
             - op: replace
               path: /spec/template/spec/updateCloudProviderConfig/manifestsConfigMapName
               valueFrom:
-                template: "cloud-config-addon-{{ .builtin.cluster.name }}"
+                template: "cloud-controller-manager-addon-{{ .builtin.cluster.name }}"
     - name: csiAddonConfigMapNamespace
       definitions:
         - selector:
@@ -381,24 +381,22 @@ spec:
         namespace: ${NAMESPACE}
         name: ${IDENTITY_SECRET_NAME}
       loadBalancerConfig:
-        ipamType: dhcp
+        ipamType: pool
+        ipPoolRef: ${IP_POOL_REF}
         listeners:
           - name: rke2-server
             port: 9345
             protocol: TCP
             backendPort: 9345
       targetNamespace: ${TARGET_NAMESPACE}
-      controlPlaneEndpoint:
-        host: "0.0.0.0"
-        port: 6443
       updateCloudProviderConfig:
         cloudConfigCredentialsSecretKey: cloud-config
         cloudConfigCredentialsSecretName: cloud-config
-        manifestsConfigMapKey: cloud-config.yaml
-        manifestsConfigMapName: cloud-config-addon
+        manifestsConfigMapKey: harvester-csi-deployment.yaml
+        manifestsConfigMapName: cloud-controller-manager-addon
         manifestsConfigMapNamespace: ${NAMESPACE}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-control-plane
@@ -444,7 +442,7 @@ spec:
       volumes: []
       networks: []
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-worker

--- a/test/certification/suites/import-gitops/import_gitops_test.go
+++ b/test/certification/suites/import-gitops/import_gitops_test.go
@@ -30,6 +30,7 @@ var _ = Describe("[Harvester] [RKE2] Create and delete CAPI cluster functionalit
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ClusterTemplate:           suites.HarvesterRKE2Topology,
 			ClusterName:               "caphv-gitops",
+			ClusterctlBinaryPath:      "clusterctl",
 			ControlPlaneMachineCount:  ptr.To(1),
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,

--- a/test/certification/suites/import-gitops/import_gitops_test.go
+++ b/test/certification/suites/import-gitops/import_gitops_test.go
@@ -1,0 +1,42 @@
+//go:build e2e
+// +build e2e
+
+package importgitops
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	"github.com/rancher/turtles/test/e2e"
+	"github.com/rancher/turtles/test/e2e/specs"
+
+	"github.com/rancher-sandbox/cluster-api-provider-harvester/test/certification/suites"
+)
+
+// The Turtles integration spec: provisions a real cluster on Harvester from the
+// ClusterClass template, waits for it to become Available, verifies the automatic
+// Rancher import (cattle-cluster-agent deployed downstream, fleet-managed), and
+// verifies the cluster deletes without stalling.
+var _ = Describe("[Harvester] [RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", func() {
+	BeforeEach(func() {
+		komega.SetClient(bootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+	})
+
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+		return specs.CreateUsingGitOpsSpecInput{
+			E2EConfig:                 e2e.LoadE2EConfig(),
+			BootstrapClusterProxy:     bootstrapClusterProxy,
+			ClusterTemplate:           suites.HarvesterRKE2Topology,
+			ClusterName:               "caphv-gitops",
+			ControlPlaneMachineCount:  ptr.To(1),
+			WorkerMachineCount:        ptr.To(1),
+			LabelNamespace:            true,
+			RancherManagedFleet:       true,
+			RancherServerURL:          hostName,
+			CAPIClusterCreateWaitName: "wait-rancher",
+			DeleteClusterWaitName:     "wait-delete-cluster",
+		}
+	})
+})

--- a/test/certification/suites/import-gitops/suite_test.go
+++ b/test/certification/suites/import-gitops/suite_test.go
@@ -5,17 +5,24 @@ package importgitops
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/turtles/test/e2e"
@@ -71,9 +78,46 @@ var _ = SynchronizedBeforeSuite(
 		// ports are exposed on the host through the kind extraPortMappings).
 		By("Deploying the nginx ingress (hostPort)")
 		Expect(turtlesframework.Apply(ctx, proxy, e2e.NginxIngress)).To(Succeed())
-		Expect(turtlesframework.Apply(ctx, proxy, e2e.IngressClassPatch)).To(Succeed())
 		waitForDeploymentAvailableOn(proxy, "ingress-nginx-controller", "ingress-nginx",
 			e2eConfig.GetIntervals("default", "wait-controllers")...)
+
+		// The controller Deployment turning Available does not mean the admission
+		// webhook is servable yet; installing Rancher too early fails on
+		// "failed calling webhook validate.nginx.ingress.kubernetes.io".
+		By("Waiting for the nginx admission webhook endpoints")
+		Eventually(func(g Gomega) {
+			endpoints := &corev1.Endpoints{}
+			g.Expect(proxy.GetClient().Get(ctx, types.NamespacedName{
+				Namespace: "ingress-nginx", Name: "ingress-nginx-controller-admission",
+			}, endpoints)).To(Succeed())
+			g.Expect(endpoints.Subsets).ToNot(BeEmpty())
+			g.Expect(endpoints.Subsets[0].Addresses).ToNot(BeEmpty())
+		}, e2eConfig.GetIntervals("default", "wait-controllers")...).Should(Succeed())
+
+		// Pods inside kind cannot reach the host IP that RANCHER_HOSTNAME resolves to
+		// (hairpin through the podman port-forward times out), yet Turtles must download
+		// the Rancher import manifest from the server-url. Point the hostname to the
+		// kind node's internal IP in the cluster DNS: the node exposes nginx through
+		// hostPorts, so in-cluster traffic reaches Rancher while external workload VMs
+		// keep using the host-mapped ports.
+		By("Resolving the Rancher hostname to the kind node inside the cluster DNS")
+		nodeList := &corev1.NodeList{}
+		Expect(proxy.GetClient().List(ctx, nodeList)).To(Succeed())
+		Expect(nodeList.Items).ToNot(BeEmpty())
+		var nodeIP string
+		for _, addr := range nodeList.Items[0].Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				nodeIP = addr.Address
+			}
+		}
+		Expect(nodeIP).ToNot(BeEmpty(), "kind node must expose an internal IP")
+		coreDNS := &corev1.ConfigMap{}
+		Expect(proxy.GetClient().Get(ctx, types.NamespacedName{Namespace: "kube-system", Name: "coredns"}, coreDNS)).To(Succeed())
+		hostsBlock := fmt.Sprintf("    hosts {\n       %s %s\n       fallthrough\n    }\n    forward", nodeIP, e2eConfig.GetVariableOrEmpty("RANCHER_HOSTNAME"))
+		coreDNS.Data["Corefile"] = strings.Replace(coreDNS.Data["Corefile"], "    forward", hostsBlock, 1)
+		Expect(proxy.GetClient().Update(ctx, coreDNS)).To(Succeed())
+		Expect(proxy.GetClient().DeleteAllOf(ctx, &corev1.Pod{},
+			client.InNamespace("kube-system"), client.MatchingLabels{"k8s-app": "kube-dns"})).To(Succeed())
 
 		By("Deploying Rancher " + e2eConfig.GetVariableOrEmpty("RANCHER_VERSION"))
 		rancherHookResult := testenv.DeployRancher(ctx, testenv.DeployRancherInput{
@@ -113,6 +157,36 @@ var _ = SynchronizedBeforeSuite(
 			waitForDeploymentAvailableOn(proxy, nn.name, nn.namespace,
 				e2eConfig.GetIntervals("default", "wait-controllers")...)
 		}
+
+		// Workaround for a Turtles 0.26 import race: if the freshly created v3 cluster
+		// gets replaced, the CAPI Cluster is annotated imported=true before the agent
+		// was ever applied and the import is never retried (the controller skips
+		// clusters carrying the annotation). Strip it while premature; a genuinely
+		// deleting cluster keeps it (the deletion flow relies on it).
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(30 * time.Second):
+				}
+
+				clusters := &clusterv1.ClusterList{}
+				if err := proxy.GetClient().List(ctx, clusters); err != nil {
+					continue
+				}
+
+				for i := range clusters.Items {
+					cl := &clusters.Items[i]
+					if cl.Annotations["imported"] != "true" || !cl.DeletionTimestamp.IsZero() {
+						continue
+					}
+
+					delete(cl.Annotations, "imported")
+					_ = proxy.GetClient().Update(ctx, cl)
+				}
+			}
+		}()
 
 		data, err := json.Marshal(e2e.Setup{
 			ClusterName:     setupClusterResult.ClusterName,

--- a/test/certification/suites/import-gitops/suite_test.go
+++ b/test/certification/suites/import-gitops/suite_test.go
@@ -1,0 +1,179 @@
+//go:build e2e
+// +build e2e
+
+package importgitops
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	capiframework "sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/rancher/turtles/test/e2e"
+	turtlesframework "github.com/rancher/turtles/test/framework"
+	"github.com/rancher/turtles/test/testenv"
+
+	"github.com/rancher-sandbox/cluster-api-provider-harvester/test/certification/suites"
+)
+
+var (
+	ctx = context.Background()
+
+	e2eConfig             *clusterctl.E2EConfig
+	setupClusterResult    *testenv.SetupTestClusterResult
+	bootstrapClusterProxy capiframework.ClusterProxy
+	hostName              string
+)
+
+func TestCAPHVImportGitops(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	RunSpecs(t, "caphv-import-gitops")
+}
+
+// SynchronizedBeforeSuite stands up the full Rancher + Turtles management stack the
+// Turtles integration suite expects (mirroring rancher/turtles-integration-suite-example)
+// and installs the CAPHV provider on top. It runs with
+// MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind: the kind cluster maps ports 80/443 onto
+// the host so the Rancher server-url (RANCHER_HOSTNAME, e.g. <host-ip>.sslip.io) is
+// reachable from the workload VMs provisioned on the real Harvester — a requirement for
+// the cattle-cluster-agent import step that isolated-kind cannot satisfy.
+var _ = SynchronizedBeforeSuite(
+	func() []byte {
+		e2eConfig = e2e.LoadE2EConfig()
+		e2eConfig.ManagementClusterName = e2eConfig.ManagementClusterName + "-caphv-gitops"
+
+		By("Setting up the management cluster (kind with host port mappings)")
+		setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
+			E2EConfig: e2eConfig,
+			Scheme:    e2e.InitScheme(),
+		})
+		proxy := setupClusterResult.BootstrapClusterProxy
+
+		By("Deploying cert-manager")
+		testenv.DeployCertManager(ctx, testenv.DeployCertManagerInput{
+			BootstrapClusterProxy: proxy,
+		})
+
+		// The internal-kind ingress path of RancherDeployIngress expects a LoadBalancer
+		// setup; on a bare kind the hostPort-based nginx manifest is the right fit (its
+		// ports are exposed on the host through the kind extraPortMappings).
+		By("Deploying the nginx ingress (hostPort)")
+		Expect(turtlesframework.Apply(ctx, proxy, e2e.NginxIngress)).To(Succeed())
+		Expect(turtlesframework.Apply(ctx, proxy, e2e.IngressClassPatch)).To(Succeed())
+		waitForDeploymentAvailableOn(proxy, "ingress-nginx-controller", "ingress-nginx",
+			e2eConfig.GetIntervals("default", "wait-controllers")...)
+
+		By("Deploying Rancher " + e2eConfig.GetVariableOrEmpty("RANCHER_VERSION"))
+		rancherHookResult := testenv.DeployRancher(ctx, testenv.DeployRancherInput{
+			BootstrapClusterProxy:   proxy,
+			RancherIngressClassName: "nginx",
+			RancherPatches:          [][]byte{e2e.RancherSettingPatch},
+			RancherWaitInterval:     e2eConfig.GetIntervals("default", "wait-rancher"),
+			ControllerWaitInterval:  e2eConfig.GetIntervals("default", "wait-controllers"),
+		})
+
+		// Rancher's system chart controller installs the released Turtles, which brings
+		// up the CAPI core; the RKE2 providers and CAPHV are declared explicitly
+		// (a fresh Rancher does not install them by itself).
+		By("Waiting for the Rancher-managed Turtles + CAPI core to come up")
+		for _, nn := range []struct{ name, namespace string }{
+			{"rancher-turtles-controller-manager", e2e.NewRancherTurtlesNamespace},
+			{"capi-controller-manager", "cattle-capi-system"},
+		} {
+			waitForDeploymentAvailableOn(proxy, nn.name, nn.namespace,
+				e2eConfig.GetIntervals("default", "wait-rancher")...)
+		}
+
+		By("Deploying the RKE2 providers and the CAPHV " + e2eConfig.GetVariableOrEmpty("CAPHV_VERSION") + " CAPIProvider")
+		for _, template := range [][]byte{suites.CAPIProviderRKE2Turtles, suites.CAPIProviderHarvesterTurtles} {
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Proxy:    proxy,
+				Template: template,
+			})).To(Succeed(), "Failed to apply CAPIProvider manifest")
+		}
+
+		By("Waiting for the provider deployments to be available")
+		for _, nn := range []struct{ name, namespace string }{
+			{"rke2-bootstrap-controller-manager", "rke2-bootstrap-system"},
+			{"rke2-control-plane-controller-manager", "rke2-control-plane-system"},
+			{"caphv-controller-manager", "caphv-system"},
+		} {
+			waitForDeploymentAvailableOn(proxy, nn.name, nn.namespace,
+				e2eConfig.GetIntervals("default", "wait-controllers")...)
+		}
+
+		data, err := json.Marshal(e2e.Setup{
+			ClusterName:     setupClusterResult.ClusterName,
+			KubeconfigPath:  setupClusterResult.KubeconfigPath,
+			RancherHostname: rancherHookResult.Hostname,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		return data
+	},
+	func(sharedData []byte) {
+		setup := e2e.Setup{}
+		Expect(json.Unmarshal(sharedData, &setup)).To(Succeed())
+
+		hostName = setup.RancherHostname
+
+		// LoadE2EConfig also exports the config variables into this process' environment.
+		e2eConfig = e2e.LoadE2EConfig()
+
+		bootstrapClusterProxy = capiframework.NewClusterProxy(
+			setup.ClusterName,
+			setup.KubeconfigPath,
+			e2e.InitScheme(),
+		)
+		Expect(bootstrapClusterProxy).ToNot(BeNil(), "cluster proxy should not be nil")
+	},
+)
+
+var _ = SynchronizedAfterSuite(
+	func() {},
+	func() {
+		if bootstrapClusterProxy != nil {
+			// Collects the management cluster state through crust-gather when the
+			// kubectl plugin is installed (scripts/ensure-crust-gather.sh).
+			By("Dumping artifacts from the bootstrap cluster")
+			testenv.DumpBootstrapCluster(ctx, bootstrapClusterProxy.GetKubeconfigPath())
+		}
+
+		if setupClusterResult == nil {
+			return
+		}
+
+		skipCleanup, _ := strconv.ParseBool(e2eConfig.GetVariableOrEmpty(e2e.SkipResourceCleanupVar))
+		if skipCleanup {
+			return
+		}
+
+		testenv.CleanupTestCluster(ctx, testenv.CleanupTestClusterInput{
+			SetupTestClusterResult: *setupClusterResult,
+		})
+	},
+)
+
+// waitForDeploymentAvailableOn waits on the given proxy (usable before the package-level
+// bootstrapClusterProxy is set in the all-processes setup).
+func waitForDeploymentAvailableOn(proxy capiframework.ClusterProxy, name, namespace string, intervals ...interface{}) {
+	capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+		Getter: proxy.GetClient(),
+		Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		}},
+	}, intervals...)
+}

--- a/test/certification/suites/import-gitops/suite_test.go
+++ b/test/certification/suites/import-gitops/suite_test.go
@@ -171,20 +171,26 @@ var _ = SynchronizedBeforeSuite(
 				case <-time.After(30 * time.Second):
 				}
 
-				clusters := &clusterv1.ClusterList{}
-				if err := proxy.GetClient().List(ctx, clusters); err != nil {
-					continue
-				}
+				// Best-effort: once the suite tears the cluster down, the proxy's
+				// accessors Fail (panic); swallow it instead of crashing the binary.
+				func() {
+					defer func() { _ = recover() }()
 
-				for i := range clusters.Items {
-					cl := &clusters.Items[i]
-					if cl.Annotations["imported"] != "true" || !cl.DeletionTimestamp.IsZero() {
-						continue
+					clusters := &clusterv1.ClusterList{}
+					if err := proxy.GetClient().List(ctx, clusters); err != nil {
+						return
 					}
 
-					delete(cl.Annotations, "imported")
-					_ = proxy.GetClient().Update(ctx, cl)
-				}
+					for i := range clusters.Items {
+						cl := &clusters.Items[i]
+						if cl.Annotations["imported"] != "true" || !cl.DeletionTimestamp.IsZero() {
+							continue
+						}
+
+						delete(cl.Annotations, "imported")
+						_ = proxy.GetClient().Update(ctx, cl)
+					}
+				}()
 			}
 		}()
 


### PR DESCRIPTION
## What this PR does

Adds the **Turtles integration suite** (`CreateUsingGitOpsSpec`) for CAPHV — the same
spec the Turtles team runs for certified providers, modeled on
[`rancher/turtles-integration-suite-example`](https://github.com/rancher/turtles-integration-suite-example) —
plus two provider fixes it surfaced.

### New suite: `test/certification/suites/import-gitops/`

Full lifecycle against a **real Harvester** (validated end-to-end, `SUCCESS! 1 Passed | 0 Failed`):

1. kind + cert-manager + nginx + released Rancher, Turtles + CAPI core via Rancher's
   system chart, RKE2 providers and the CAPHV `CAPIProvider` on top;
2. ClusterClass-based RKE2 cluster (1 CP + 1 worker) provisioned on Harvester through
   Fleet/GitOps, control-plane LB backed by a Harvester IP pool;
3. cluster reaches `Available`, Rancher auto-imports it (cattle-cluster-agent deployed
   and connected, v3 record ready);
4. deletion completes cleanly (Rancher record removed, VMs/LB/pool IPs released).

Artifacts are collected with `crust-gather` (`scripts/ensure-crust-gather.sh`). In CI
the suite runs on a **self-hosted runner inside the test environment** (same pattern as
the Turtles vSphere runner): schedule + manual dispatch only, guarded so it never runs
on pull requests (`.github/workflows/certification-import-gitops.yml`).

### Provider fixes

- **kustomize: restore CA injection on the `harvesterclustertemplates` CRD** — the
  `replacements` excluded it, shipping a raw `CERTIFICATE_NAMESPACE/CERTIFICATE_NAME`
  annotation in the release manifests. Harmless with plain `kubectl apply`, but
  Turtles' provider machinery parses the components and fails on the unsubstituted
  placeholder (`could not find secret for certificate ...`), so a v0.5.0 install
  through a `CAPIProvider` cannot come up. Requires a patch release.
- **RBAC: allow reading `clusters.provisioning.cattle.io`** — the fleet-integration
  path lists Rancher provisioning clusters; under a real Rancher the CRD exists and
  the controller gets `Forbidden` (previously unnoticed because without Rancher the
  lookup exits early on the missing CRD).

### Also

- `docs/compatibility.md`: CAPHV ↔ Rancher/Turtles/CAPI version matrix.
- `test/certification/README.md`: tier documentation and runner environment notes.

### Notes for reviewers

- The suite templates reference `controlplane`/`bootstrap` RKE2 APIs at `v1beta2`
  (CAPI v1.12 topology writes the v1beta2 contract shape).
- The `imported` annotation watcher in the suite works around a Turtles 0.26 race
  (annotation applied before the agent manifest when the v3 cluster record is
  replaced; the import is then never retried). An upstream Turtles issue is being
  prepared.
