### PR TITLE
ci: make the release flow compatible with immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
     - "v*.*.*"
+  # Clean re-trigger path when a tag push fails to start the workflow: with
+  # immutable releases, deleting and re-pushing a tag is no longer an option.
+  workflow_dispatch: {}
 
 env:
   REGISTRY: ghcr.io
@@ -110,7 +113,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [build]
+    # Publishing must be the very last step of the workflow: once published the
+    # release becomes immutable (assets and tag frozen), so everything that
+    # belongs to it must exist beforehand.
+    needs: [build, helm]
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -124,15 +130,33 @@ jobs:
     - name: Update manifests
       run: |
         make release RELEASE_TAG=${{ env.TAG }} ORG=${{ env.ORG }}
-    - name: Create GitHub Release
+    - name: Create draft GitHub Release and publish it (final, immutable from here)
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if gh release view ${{ github.ref_name }} > /dev/null; then
-          echo ${{ github.ref_name }} release exists
-        else
-          gh release create ${{ github.ref_name }} --generate-notes
+        # gh release view also resolves drafts: only a published release counts.
+        if [ "$(gh release view ${{ github.ref_name }} --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
+          echo "${{ github.ref_name }} is already published (immutable), nothing to do"
+          exit 0
         fi
-        gh release upload ${{ github.ref_name }} out/metadata.yaml --clobber
-        gh release upload ${{ github.ref_name }} out/infrastructure-components.yaml --clobber
+        # Drafts are not resolvable by tag; a stale one left by a failed run may
+        # miss assets, so drop it and recreate the draft in a known-good state.
+        lookup_draft() {
+          gh api "repos/${{ github.repository }}/releases?per_page=100" --jq '.[] | select(.draft and .tag_name == "${{ github.ref_name }}") | .id' | head -1
+        }
+        STALE_ID=$(lookup_draft)
+        if [ -n "$STALE_ID" ]; then
+          gh api -X DELETE repos/${{ github.repository }}/releases/$STALE_ID
+        fi
+        gh release create ${{ github.ref_name }} --draft --generate-notes out/metadata.yaml out/infrastructure-components.yaml
+        # The list API lags slightly behind the creation: retry the id lookup.
+        DRAFT_ID=""
+        for _ in $(seq 1 10); do
+          DRAFT_ID=$(lookup_draft)
+          [ -n "$DRAFT_ID" ] && break
+          sleep 3
+        done
+        [ -n "$DRAFT_ID" ] || { echo "draft not found after creation"; exit 1; }
+        gh api -X PATCH repos/${{ github.repository }}/releases/$DRAFT_ID -F draft=false > /dev/null
+        echo "Release ${{ github.ref_name }} published"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,6 +21,19 @@ GHCR, the Helm OCI chart, `infrastructure-components.yaml` + `metadata.yaml` +
 cluster templates as release assets, cosign signatures (verify with **cosign v3+**:
 v2 wrongly reports "no signatures" on OCI 1.1 bundles) and build provenance.
 
+The GitHub release is created as a **draft** carrying all assets, and publishing it
+is the **last step**, after the image and the chart jobs succeeded. Releases are
+**immutable** once published (rancher-security release hardening): assets can no
+longer be added, replaced or deleted, and the tag can no longer be moved or removed.
+Consequences:
+
+- If the tag push does not start the workflow, dispatch it **on the tag ref**
+  (`gh workflow run release.yml --ref vX.Y.Z`) — do **not** delete and re-push the
+  tag.
+- If a run fails midway, re-run it: the draft is reused, nothing was published yet.
+- A defect discovered in a *published* release cannot be fixed in place: cut a new
+  patch release. Only the release notes remain editable.
+
 ## After the release is published
 
 1. **Certification defaults** — bump `CAPHV_VERSION` and `CAPHV_COMPONENTS_URL` in


### PR DESCRIPTION
## What this PR does

Makes the release flow compatible with **immutable releases**, following the
[ecm-distro-tools guideline](https://github.com/rancher/ecm-distro-tools/tree/master/actions/publish-image#immutable-releases). Part of #218.

- The GitHub release is now created as a **draft** carrying all its assets
  (`infrastructure-components.yaml`, `metadata.yaml`), and publishing it is the
  **last step** of the workflow, gated on the image and Helm chart jobs
  (`needs: [build, helm]`). Nothing is attached or modified after publication.
- Idempotent re-runs: a published release is left untouched; a stale draft left by
  a failed run is replaced by a fresh one (a partial draft could be missing assets).
- New `workflow_dispatch` trigger as the re-trigger path when a tag push fails to
  start the workflow (`gh workflow run release.yml --ref vX.Y.Z`) — deleting and
  re-pushing tags is no longer an option under immutability.
- `docs/release-process.md` documents the new constraints (a defect in a published
  release requires a new patch release; only the notes stay editable).

## Validation

Exercised end to end on a fork with a test tag: draft created with both assets,
published as the final step; re-run with a stale draft present → replaced and
published; already-published guard verified. (Test release, tag and image cleaned
up afterwards.)

## Follow-up (requires repo admin)

Enabling the *immutable releases* repository setting itself needs admin permissions
on this repo — tracked in #218.
