### PR TITLE
fix: resolve the image StorageClass from the image status

### DIFF
--- a/internal/controller/harvestermachine_controller.go
+++ b/internal/controller/harvestermachine_controller.go
@@ -757,8 +757,22 @@ func createVMFromHarvesterMachine(hvScope *Scope) (*kubevirtv1.VirtualMachine, e
 	return hvCreatedMachine, nil
 }
 
+// storageClassForImage returns the StorageClass backing a Harvester VM image.
+// Harvester publishes it in the image status; up to Harvester 1.8.0 it happened to
+// be "longhorn-<image>", but 1.8.1 names it "lh-<uuid>", so the status is the only
+// reliable source. The old convention is kept as a fallback for images whose status
+// is not populated yet.
+func storageClassForImage(vmImage *harvesterv1beta1.VirtualMachineImage) string {
+	if vmImage.Status.StorageClassName != "" {
+		return vmImage.Status.StorageClassName
+	}
+
+	return "longhorn-" + vmImage.Name
+}
+
 // buildPVCForVolume creates a PersistentVolumeClaim for a single volume.
-// For "image" volumes, the PVC references a Harvester VM image (StorageClass = longhorn-<imageName>).
+// For "image" volumes, the PVC references a Harvester VM image (StorageClass resolved
+// from the image status).
 // For "storageClass" volumes, the PVC uses the specified StorageClass directly (blank data disk).
 func buildPVCForVolume(
 	vol *infrav1.Volume,
@@ -794,7 +808,7 @@ func buildPVCForVolume(
 			return nil, errors.Wrapf(err, "unable to find VM image %s", vol.ImageName)
 		}
 
-		scName := "longhorn-" + vmImage.Name
+		scName := storageClassForImage(vmImage)
 		pvc.Spec.StorageClassName = &scName
 		pvc.Annotations[hvAnnotationImageID] = vmImage.Namespace + "/" + vmImage.Name
 

--- a/internal/controller/harvestermachine_controller_test.go
+++ b/internal/controller/harvestermachine_controller_test.go
@@ -848,6 +848,27 @@ var _ = Describe("dhclientScriptContent", func() {
 // Tests for buildPVCForVolume
 // =============================================================================
 
+var _ = Describe("storageClassForImage", func() {
+	It("should use the storage class the image resolved to", func() {
+		// Harvester 1.8.1 names image storage classes lh-<uuid>, so the name can
+		// no longer be derived from the image name.
+		img := &harvesterv1beta1.VirtualMachineImage{
+			ObjectMeta: metav1.ObjectMeta{Name: "image-rs64h", Namespace: "default"},
+			Status: harvesterv1beta1.VirtualMachineImageStatus{
+				StorageClassName: "lh-c141a832-fc3d-41db-b613-722c87c545e1",
+			},
+		}
+		Expect(storageClassForImage(img)).To(Equal("lh-c141a832-fc3d-41db-b613-722c87c545e1"))
+	})
+
+	It("should fall back to the longhorn-<image> convention when the status is empty", func() {
+		img := &harvesterv1beta1.VirtualMachineImage{
+			ObjectMeta: metav1.ObjectMeta{Name: "image-rs64h", Namespace: "default"},
+		}
+		Expect(storageClassForImage(img)).To(Equal("longhorn-image-rs64h"))
+	})
+})
+
 var _ = Describe("buildPVCForVolume", func() {
 	It("should build a PVC for storageClass volume type", func() {
 		size := resource.MustParse("10Gi")


### PR DESCRIPTION
## Problem

VMs were provisioned with a `harvesterhci.io/volumeClaimTemplates` annotation whose
StorageClass was composed as `longhorn-<image resource name>`. Harvester no longer
names image StorageClasses that way: it now uses `lh-<uuid>` and publishes the actual
name in `VirtualMachineImage.status.storageClassName`. The composed name does not
exist, so the PVC stays `Pending` and Harvester logs:

```
failed to get storage class longhorn-image-xxxxx
```

Fixes #211.

## Fix

Read the StorageClass Harvester publishes in the image status, keeping the old
convention as a fallback for images whose status is not populated yet.

## Scope is wider than the issue title suggests

The issue was reported on Harvester 1.8.1, but this is not version-specific: it
depends on **when the image was created**. On a Harvester **1.8.0** cluster, images
imported months ago still carry `longhorn-<image>` StorageClasses, while an image
created today gets `lh-<uuid>`:

```
image-dqhmm  (Feb 2026)  status.storageClassName=longhorn-image-dqhmm
image-fvkzr  (created today) status.storageClassName=lh-14d1e229-ddd6-496d-a925-413e9cc0b855
```

That is also why CI did not catch it: the certification suites use images imported
long ago. Any user creating a fresh image is affected.

## Validation

- Unit test on the resolution itself (status wins, convention as fallback).
- Functional run on a real Harvester with a **freshly created image** (`lh-*`
  StorageClass), full Turtles integration suite:
  - before the fix: PVC `Pending`, `ProvisioningFailed: storageclass "longhorn-image-fvkzr" not found`
  - after the fix: PVC `Bound` on `lh-14d1e229-ddd6-496d-a925-413e9cc0b855`, VM boots,
    cluster provisions.
