### PR TITLE
feat: network-aware IP pool selection for ipPoolRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Network-aware IP pool selection**: when `ipPoolRefs` lists several pools, a pool
+  whose Harvester `spec.selector.network` designates a VM network is only used for
+  machines attached to that network (a pool with no selector network keeps matching
+  any machine). Separate address ranges for control-plane and worker networks now
+  work with a single pool list, and a machine whose networks match no listed pool
+  gets an explicit error instead of an address from another network.
+
 ## [v0.6.0] - 2026-07-20
 
 ### Changed

--- a/api/v1alpha1/harvestercluster_types.go
+++ b/api/v1alpha1/harvestercluster_types.go
@@ -156,9 +156,12 @@ type VMNetworkConfig struct {
 	IPPoolRef string `json:"ipPoolRef,omitempty"`
 
 	// IPPoolRefs is a list of references to existing IPPools in Harvester.
-	// Pools are tried in order: if the first pool is exhausted, allocation
-	// falls back to the next pool. This enables larger deployments and
-	// multi-subnet configurations.
+	// Pools are tried in order: if a pool is exhausted, allocation falls back
+	// to the next one. A pool whose selector designates a network (the IPPool
+	// spec.selector.network field in Harvester) is only used for machines
+	// attached to that network, so distinct pools can serve, for example, the
+	// control-plane and worker networks of one cluster; a pool with no
+	// selector network is used for any machine.
 	// +optional
 	IPPoolRefs []string `json:"ipPoolRefs,omitempty"`
 

--- a/api/v1alpha1/harvestercluster_webhook.go
+++ b/api/v1alpha1/harvestercluster_webhook.go
@@ -77,8 +77,8 @@ func validateHarvesterCluster(r *HarvesterCluster) (admission.Warnings, error) {
 
 	if r.Spec.VMNetworkConfig != nil {
 		vmCfg := r.Spec.VMNetworkConfig
-		if vmCfg.IPPoolRef == "" && vmCfg.IPPool == nil {
-			errs = append(errs, "spec.vmNetworkConfig requires either ipPoolRef or ipPool")
+		if len(vmCfg.GetIPPoolRefs()) == 0 && vmCfg.IPPool == nil {
+			errs = append(errs, "spec.vmNetworkConfig requires one of ipPoolRef, ipPoolRefs or ipPool")
 		}
 
 		if vmCfg.Gateway == "" {

--- a/api/v1beta1/harvestercluster_types.go
+++ b/api/v1beta1/harvestercluster_types.go
@@ -156,9 +156,12 @@ type VMNetworkConfig struct {
 	IPPoolRef string `json:"ipPoolRef,omitempty"`
 
 	// IPPoolRefs is a list of references to existing IPPools in Harvester.
-	// Pools are tried in order: if the first pool is exhausted, allocation
-	// falls back to the next pool. This enables larger deployments and
-	// multi-subnet configurations.
+	// Pools are tried in order: if a pool is exhausted, allocation falls back
+	// to the next one. A pool whose selector designates a network (the IPPool
+	// spec.selector.network field in Harvester) is only used for machines
+	// attached to that network, so distinct pools can serve, for example, the
+	// control-plane and worker networks of one cluster; a pool with no
+	// selector network is used for any machine.
 	// +optional
 	IPPoolRefs []string `json:"ipPoolRefs,omitempty"`
 

--- a/api/v1beta1/harvestercluster_webhook.go
+++ b/api/v1beta1/harvestercluster_webhook.go
@@ -77,8 +77,8 @@ func validateHarvesterCluster(r *HarvesterCluster) (admission.Warnings, error) {
 
 	if r.Spec.VMNetworkConfig != nil {
 		vmCfg := r.Spec.VMNetworkConfig
-		if vmCfg.IPPoolRef == "" && vmCfg.IPPool == nil {
-			errs = append(errs, "spec.vmNetworkConfig requires either ipPoolRef or ipPool")
+		if len(vmCfg.GetIPPoolRefs()) == 0 && vmCfg.IPPool == nil {
+			errs = append(errs, "spec.vmNetworkConfig requires one of ipPoolRef, ipPoolRefs or ipPool")
 		}
 
 		if vmCfg.Gateway == "" {

--- a/api/v1beta1/harvestercluster_webhook_unit_test.go
+++ b/api/v1beta1/harvestercluster_webhook_unit_test.go
@@ -44,13 +44,17 @@ func TestValidateVMNetworkConfigPoolSources(t *testing.T) {
 	for _, tc := range cases {
 		c := validCluster()
 		c.Spec.VMNetworkConfig = tc.cfg
+
 		_, err := validateHarvesterCluster(c)
+
 		if tc.wantErr && err == nil {
 			t.Errorf("%s: expected an error", tc.name)
 		}
+
 		if !tc.wantErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 		}
+
 		if tc.wantErr && err != nil && !strings.Contains(err.Error(), "ipPoolRefs") {
 			t.Errorf("%s: error should mention ipPoolRefs: %v", tc.name, err)
 		}

--- a/api/v1beta1/harvestercluster_webhook_unit_test.go
+++ b/api/v1beta1/harvestercluster_webhook_unit_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+)
+
+func validCluster() *HarvesterCluster {
+	return &HarvesterCluster{
+		Spec: HarvesterClusterSpec{
+			TargetNamespace:    "default",
+			IdentitySecret:     SecretKey{Namespace: "default", Name: "id"},
+			LoadBalancerConfig: LoadBalancerConfig{IPAMType: IPAMType(DHCP)},
+		},
+	}
+}
+
+func TestValidateVMNetworkConfigPoolSources(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *VMNetworkConfig
+		wantErr bool
+	}{
+		{"single ipPoolRef", &VMNetworkConfig{IPPoolRef: "pool-a", Gateway: "10.0.0.1", SubnetMask: "255.255.255.0"}, false},
+		{"ipPoolRefs list only", &VMNetworkConfig{IPPoolRefs: []string{"pool-a", "pool-b"}, Gateway: "10.0.0.1", SubnetMask: "255.255.255.0"}, false},
+		{"no pool source", &VMNetworkConfig{Gateway: "10.0.0.1", SubnetMask: "255.255.255.0"}, true},
+	}
+	for _, tc := range cases {
+		c := validCluster()
+		c.Spec.VMNetworkConfig = tc.cfg
+		_, err := validateHarvesterCluster(c)
+		if tc.wantErr && err == nil {
+			t.Errorf("%s: expected an error", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if tc.wantErr && err != nil && !strings.Contains(err.Error(), "ipPoolRefs") {
+			t.Errorf("%s: error should mention ipPoolRefs: %v", tc.name, err)
+		}
+	}
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_harvesterclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_harvesterclusters.yaml
@@ -274,9 +274,12 @@ spec:
                   ipPoolRefs:
                     description: |-
                       IPPoolRefs is a list of references to existing IPPools in Harvester.
-                      Pools are tried in order: if the first pool is exhausted, allocation
-                      falls back to the next pool. This enables larger deployments and
-                      multi-subnet configurations.
+                      Pools are tried in order: if a pool is exhausted, allocation falls back
+                      to the next one. A pool whose selector designates a network (the IPPool
+                      spec.selector.network field in Harvester) is only used for machines
+                      attached to that network, so distinct pools can serve, for example, the
+                      control-plane and worker networks of one cluster; a pool with no
+                      selector network is used for any machine.
                     items:
                       type: string
                     type: array
@@ -653,9 +656,12 @@ spec:
                   ipPoolRefs:
                     description: |-
                       IPPoolRefs is a list of references to existing IPPools in Harvester.
-                      Pools are tried in order: if the first pool is exhausted, allocation
-                      falls back to the next pool. This enables larger deployments and
-                      multi-subnet configurations.
+                      Pools are tried in order: if a pool is exhausted, allocation falls back
+                      to the next one. A pool whose selector designates a network (the IPPool
+                      spec.selector.network field in Harvester) is only used for machines
+                      attached to that network, so distinct pools can serve, for example, the
+                      control-plane and worker networks of one cluster; a pool with no
+                      selector network is used for any machine.
                     items:
                       type: string
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_harvesterclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_harvesterclustertemplates.yaml
@@ -302,9 +302,12 @@ spec:
                           ipPoolRefs:
                             description: |-
                               IPPoolRefs is a list of references to existing IPPools in Harvester.
-                              Pools are tried in order: if the first pool is exhausted, allocation
-                              falls back to the next pool. This enables larger deployments and
-                              multi-subnet configurations.
+                              Pools are tried in order: if a pool is exhausted, allocation falls back
+                              to the next one. A pool whose selector designates a network (the IPPool
+                              spec.selector.network field in Harvester) is only used for machines
+                              attached to that network, so distinct pools can serve, for example, the
+                              control-plane and worker networks of one cluster; a pool with no
+                              selector network is used for any machine.
                             items:
                               type: string
                             type: array
@@ -614,9 +617,12 @@ spec:
                           ipPoolRefs:
                             description: |-
                               IPPoolRefs is a list of references to existing IPPools in Harvester.
-                              Pools are tried in order: if the first pool is exhausted, allocation
-                              falls back to the next pool. This enables larger deployments and
-                              multi-subnet configurations.
+                              Pools are tried in order: if a pool is exhausted, allocation falls back
+                              to the next one. A pool whose selector designates a network (the IPPool
+                              spec.selector.network field in Harvester) is only used for machines
+                              attached to that network, so distinct pools can serve, for example, the
+                              control-plane and worker networks of one cluster; a pool with no
+                              selector network is used for any machine.
                             items:
                               type: string
                             type: array

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -938,6 +938,28 @@ Pools are tried in order. When `capi-pool-subnet-a` is exhausted, allocation fal
 `capi-pool-subnet-b`, then `capi-pool-subnet-c`. Each machine tracks which pool it allocated
 from in `status.allocatedPoolRef` for accurate IP release on deletion.
 
+**Network-aware selection**: a pool whose Harvester `spec.selector.network` designates a VM
+network is only considered for machines attached to that network; a pool without a selector
+network is considered for any machine. This makes separate address ranges per machine role
+possible with a single list, for example a dedicated control-plane network and a worker
+network:
+
+```yaml
+# Harvester side: one pool per network
+# ippool "pool-cp":      spec.selector.network: default/net-cp
+# ippool "pool-workers": spec.selector.network: default/net-workers
+spec:
+  vmNetworkConfig:
+    ipPoolRefs:
+      - "pool-cp"
+      - "pool-workers"
+```
+
+With the control-plane HarvesterMachineTemplate attached to `default/net-cp` and the worker
+template attached to `default/net-workers`, each machine allocates from the pool matching its
+own network. If no listed pool matches a machine's networks, allocation fails with an explicit
+error rather than handing out an address from another network.
+
 ### CLI usage
 
 ```bash

--- a/internal/controller/harvestermachine_controller.go
+++ b/internal/controller/harvestermachine_controller.go
@@ -1314,8 +1314,13 @@ func (r *HarvesterMachineReconciler) allocateVMIP(hvScope *Scope) error {
 
 	machineID := machine.Namespace + "/" + machine.Name
 
-	// Try each pool in order until allocation succeeds
+	// Try each pool in order until allocation succeeds. Pools assigned to a
+	// network the machine is not attached to are skipped, so that clusters can
+	// dedicate distinct pools to control-plane and worker networks by listing
+	// them all in ipPoolRefs.
 	var lastErr error
+
+	skippedNetwork := 0
 
 	for _, poolRef := range poolRefs {
 		pool, err := hvScope.HarvesterClient.LoadbalancerV1beta1().IPPools().Get(
@@ -1338,6 +1343,15 @@ func (r *HarvesterMachineReconciler) allocateVMIP(hvScope *Scope) error {
 					return nil
 				}
 			}
+		}
+
+		if !locutil.PoolMatchesNetworks(pool, machine.Spec.Networks) {
+			logger.V(1).Info("Pool assigned to another network, trying next",
+				"pool", poolRef, "poolNetwork", pool.Spec.Selector.Network, "machineNetworks", machine.Spec.Networks)
+
+			skippedNetwork++
+
+			continue
 		}
 
 		// Try to allocate from this pool
@@ -1369,6 +1383,12 @@ func (r *HarvesterMachineReconciler) allocateVMIP(hvScope *Scope) error {
 
 	// All pools exhausted
 	caphvmetrics.IPPoolAllocationErrorsTotal.Inc()
+
+	if lastErr == nil && skippedNetwork > 0 {
+		return errors.Errorf(
+			"no IP pool among %v matches the machine networks %v (pools are assigned to other networks)",
+			poolRefs, machine.Spec.Networks)
+	}
 
 	return errors.Wrap(lastErr, "all configured IP pools exhausted")
 }

--- a/util/ippool.go
+++ b/util/ippool.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"net"
 	"net/netip"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -292,6 +293,52 @@ func ipToInt(ip net.IP) *big.Int {
 	}
 
 	return big.NewInt(0).SetBytes(ip.To16())
+}
+
+// PoolMatchesNetworks reports whether the pool is eligible for a machine attached
+// to the given networks. A pool whose selector carries no network is
+// network-agnostic and matches any machine; otherwise the selector network must
+// designate one of the machine's networks. Both sides accept the "name" and
+// "namespace/name" forms: when either side is unqualified only the name parts
+// are compared, and two qualified references must match exactly.
+func PoolMatchesNetworks(pool *lbv1beta1.IPPool, machineNetworks []string) bool {
+	selector := pool.Spec.Selector.Network
+	if selector == "" {
+		return true
+	}
+
+	for _, network := range machineNetworks {
+		if networkRefsEqual(selector, network) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func networkRefsEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+
+	aNS, aName := splitNetworkRef(a)
+	bNS, bName := splitNetworkRef(b)
+
+	// An unqualified reference matches on the name alone; two qualified
+	// references must agree on the namespace too.
+	if aNS == "" || bNS == "" {
+		return aName == bName
+	}
+
+	return false
+}
+
+func splitNetworkRef(ref string) (namespace, name string) {
+	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
+		return ref[:idx], ref[idx+1:]
+	}
+
+	return "", ref
 }
 
 // AllocateVMIPFromPool allocates an IP address from the given IPPool for the given machineID.

--- a/util/ippool_selection_test.go
+++ b/util/ippool_selection_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	lbv1beta1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
+)
+
+func poolWithNetwork(network string) *lbv1beta1.IPPool {
+	return &lbv1beta1.IPPool{
+		Spec: lbv1beta1.IPPoolSpec{
+			Selector: lbv1beta1.Selector{Network: network},
+		},
+	}
+}
+
+var _ = Describe("PoolMatchesNetworks", func() {
+	It("matches any machine when the pool has no selector network", func() {
+		Expect(PoolMatchesNetworks(poolWithNetwork(""), []string{"default/production"})).To(BeTrue())
+		Expect(PoolMatchesNetworks(poolWithNetwork(""), nil)).To(BeTrue())
+	})
+
+	It("matches when the selector network equals a machine network", func() {
+		Expect(PoolMatchesNetworks(poolWithNetwork("default/net-cp"),
+			[]string{"default/net-cp"})).To(BeTrue())
+		Expect(PoolMatchesNetworks(poolWithNetwork("default/net-cp"),
+			[]string{"default/net-workers", "default/net-cp"})).To(BeTrue())
+	})
+
+	It("rejects a pool assigned to another network", func() {
+		Expect(PoolMatchesNetworks(poolWithNetwork("default/net-cp"),
+			[]string{"default/net-workers"})).To(BeFalse())
+	})
+
+	It("compares unqualified names against the name part", func() {
+		Expect(PoolMatchesNetworks(poolWithNetwork("net-cp"),
+			[]string{"default/net-cp"})).To(BeTrue())
+		Expect(PoolMatchesNetworks(poolWithNetwork("default/net-cp"),
+			[]string{"net-cp"})).To(BeTrue())
+	})
+
+	It("does not cross namespaces when both sides are qualified", func() {
+		Expect(PoolMatchesNetworks(poolWithNetwork("ns1/net"),
+			[]string{"ns2/net"})).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## What this PR does

Requested by an industrial user running separate networks for control-plane and worker
nodes: with several pools listed in `ipPoolRefs`, selection only considered pool
exhaustion, so a machine could receive an address from a pool assigned to another
network.

- **Network-aware pool selection**: a pool whose Harvester `spec.selector.network`
  designates a VM network is now only used for machines attached to that network. A pool
  with no selector network keeps matching any machine, so existing setups are unchanged.
  Separate address ranges per machine role now work with a single list: one pool per
  network in `ipPoolRefs`, the control-plane template attached to its network, the worker
  template to its own, and each machine allocates from the matching pool.
- A machine whose networks match no listed pool fails with an explicit error instead of
  getting an address from another network.
- **Webhook fix**: the HarvesterCluster validation predates the multi-pool list and still
  required `ipPoolRef` or `ipPool`, rejecting a spec that only sets `ipPoolRefs`.
- Docs: `docs/operations.md` (network-aware selection section with the two-network
  example), API field documentation, CHANGELOG.

## Validation

- Unit tests for the selection rule (wildcard, qualified and unqualified references,
  namespace isolation) and for the webhook fix.
- Functional run on a real Harvester with a trap: a pool assigned to another real
  network (10.99.99.x range) listed FIRST in `ipPoolRefs`, followed by the legitimate
  pool. Full Turtles integration suite: `SUCCESS! 1 Passed | 0 Failed`, the controller
  logs show the trap pool skipped for every machine ("Pool assigned to another network,
  trying next"), and the trap pool ended the run with zero allocations. With the previous
  behavior the machines would have taken unroutable 10.99.99.x addresses and the run
  would have failed.
- The webhook fix was itself caught by this run: the first attempt failed on template
  apply because the validation rejected `ipPoolRefs`.
