### PR TITLE
feat: machine-level vmNetworkConfig for per machine type networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Per machine type network configuration** ([#234](https://github.com/rancher-sandbox/cluster-api-provider-harvester/issues/234)):
+  `spec.vmNetworkConfig` can now be set on a HarvesterMachine (typically through a
+  HarvesterMachineTemplate) to fully replace the cluster-level configuration for that machine
+  type: IP allocation uses the pools referenced there and the cloud-init static network
+  configuration uses its gateway, subnet mask and DNS settings. Combined with network-aware
+  pool selection, this lets control-plane and worker nodes live in separate networks with
+  different subnets. Machine types without the override keep the cluster-level behavior.
+  The machine-level variant accepts pool references only (no inline `ipPool`) and is mutually
+  exclusive with the static per-machine `networkConfig`.
+
 ## [v0.6.1] - 2026-07-27
 
 ### Added

--- a/api/v1alpha1/conversion.go
+++ b/api/v1alpha1/conversion.go
@@ -13,6 +13,50 @@ import (
 // exist in v1alpha1 and are NOT carried across conversion: the controller stopped
 // writing them in v0.4.0 and failures surface through the conditions instead.
 
+func convertVMNetworkConfigTo(src *VMNetworkConfig) *infrav1.VMNetworkConfig {
+	if src == nil {
+		return nil
+	}
+
+	dst := infrav1.VMNetworkConfig{
+		IPPoolRef:  src.IPPoolRef,
+		IPPoolRefs: src.IPPoolRefs,
+		Gateway:    src.Gateway,
+		SubnetMask: src.SubnetMask,
+		DNSServers: src.DNSServers,
+		DNSSearch:  src.DNSSearch,
+	}
+
+	if src.IPPool != nil {
+		pool := infrav1.IpPool(*src.IPPool)
+		dst.IPPool = &pool
+	}
+
+	return &dst
+}
+
+func convertVMNetworkConfigFrom(src *infrav1.VMNetworkConfig) *VMNetworkConfig {
+	if src == nil {
+		return nil
+	}
+
+	dst := VMNetworkConfig{
+		IPPoolRef:  src.IPPoolRef,
+		IPPoolRefs: src.IPPoolRefs,
+		Gateway:    src.Gateway,
+		SubnetMask: src.SubnetMask,
+		DNSServers: src.DNSServers,
+		DNSSearch:  src.DNSSearch,
+	}
+
+	if src.IPPool != nil {
+		pool := IpPool(*src.IPPool)
+		dst.IPPool = &pool
+	}
+
+	return &dst
+}
+
 func convertClusterSpecTo(src *HarvesterClusterSpec) infrav1.HarvesterClusterSpec {
 	dst := infrav1.HarvesterClusterSpec{
 		Server:               src.Server,
@@ -36,22 +80,7 @@ func convertClusterSpecTo(src *HarvesterClusterSpec) infrav1.HarvesterClusterSpe
 		}
 	}
 
-	if src.VMNetworkConfig != nil {
-		network := infrav1.VMNetworkConfig{
-			IPPoolRef:  src.VMNetworkConfig.IPPoolRef,
-			IPPoolRefs: src.VMNetworkConfig.IPPoolRefs,
-			Gateway:    src.VMNetworkConfig.Gateway,
-			SubnetMask: src.VMNetworkConfig.SubnetMask,
-			DNSServers: src.VMNetworkConfig.DNSServers,
-			DNSSearch:  src.VMNetworkConfig.DNSSearch,
-		}
-		if src.VMNetworkConfig.IPPool != nil {
-			pool := infrav1.IpPool(*src.VMNetworkConfig.IPPool)
-			network.IPPool = &pool
-		}
-
-		dst.VMNetworkConfig = &network
-	}
+	dst.VMNetworkConfig = convertVMNetworkConfigTo(src.VMNetworkConfig)
 
 	return dst
 }
@@ -78,22 +107,7 @@ func convertClusterSpecFrom(src *infrav1.HarvesterClusterSpec) HarvesterClusterS
 		}
 	}
 
-	if src.VMNetworkConfig != nil {
-		network := VMNetworkConfig{
-			IPPoolRef:  src.VMNetworkConfig.IPPoolRef,
-			IPPoolRefs: src.VMNetworkConfig.IPPoolRefs,
-			Gateway:    src.VMNetworkConfig.Gateway,
-			SubnetMask: src.VMNetworkConfig.SubnetMask,
-			DNSServers: src.VMNetworkConfig.DNSServers,
-			DNSSearch:  src.VMNetworkConfig.DNSSearch,
-		}
-		if src.VMNetworkConfig.IPPool != nil {
-			pool := IpPool(*src.VMNetworkConfig.IPPool)
-			network.IPPool = &pool
-		}
-
-		dst.VMNetworkConfig = &network
-	}
+	dst.VMNetworkConfig = convertVMNetworkConfigFrom(src.VMNetworkConfig)
 
 	return dst
 }
@@ -130,6 +144,8 @@ func convertMachineSpecTo(src *HarvesterMachineSpec) infrav1.HarvesterMachineSpe
 		dst.NetworkConfig = &network
 	}
 
+	dst.VMNetworkConfig = convertVMNetworkConfigTo(src.VMNetworkConfig)
+
 	return dst
 }
 
@@ -164,6 +180,8 @@ func convertMachineSpecFrom(src *infrav1.HarvesterMachineSpec) HarvesterMachineS
 		network := NetworkConfig(*src.NetworkConfig)
 		dst.NetworkConfig = &network
 	}
+
+	dst.VMNetworkConfig = convertVMNetworkConfigFrom(src.VMNetworkConfig)
 
 	return dst
 }

--- a/api/v1alpha1/harvestermachine_types.go
+++ b/api/v1alpha1/harvestermachine_types.go
@@ -109,6 +109,19 @@ type HarvesterMachineSpec struct {
 	// If set, this takes precedence over the cluster-level VMNetworkConfig IP pool allocation.
 	// +optional
 	NetworkConfig *NetworkConfig `json:"networkConfig,omitempty"`
+
+	// VMNetworkConfig is the pool-based network configuration for this machine.
+	// When set, it fully replaces the cluster-level spec.vmNetworkConfig of the
+	// HarvesterCluster for this machine: the IP is allocated from the pools
+	// referenced here, and the gateway, subnet mask and DNS settings defined here
+	// are written to the machine cloud-init. Set it in a HarvesterMachineTemplate
+	// to give one machine type (for example the workers) a network configuration
+	// different from the rest of the cluster, such as a dedicated network with its
+	// own gateway. When unset, the cluster-level configuration applies. The inline
+	// ipPool variant is not supported at the machine level; use ipPoolRef or
+	// ipPoolRefs. Mutually exclusive with networkConfig.
+	// +optional
+	VMNetworkConfig *VMNetworkConfig `json:"vmNetworkConfig,omitempty"`
 }
 
 // NetworkConfig defines static network configuration for a VM.

--- a/api/v1alpha1/harvestermachine_webhook.go
+++ b/api/v1alpha1/harvestermachine_webhook.go
@@ -116,10 +116,49 @@ func validateHarvesterMachine(r *HarvesterMachine) (admission.Warnings, error) {
 		}
 	}
 
+	errs = append(errs, validateMachineVMNetworkConfig(r)...)
+
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("validation failed for HarvesterMachine %s/%s: %s",
 			r.Namespace, r.Name, strings.Join(errs, "; "))
 	}
 
 	return nil, nil
+}
+
+// validateMachineVMNetworkConfig checks the machine-level pool-based network
+// configuration override.
+func validateMachineVMNetworkConfig(r *HarvesterMachine) []string {
+	vmCfg := r.Spec.VMNetworkConfig
+	if vmCfg == nil {
+		return nil
+	}
+
+	var errs []string
+
+	if r.Spec.NetworkConfig != nil {
+		errs = append(errs, "spec.vmNetworkConfig and spec.networkConfig are mutually exclusive")
+	}
+
+	if vmCfg.IPPool != nil {
+		errs = append(errs, "spec.vmNetworkConfig.ipPool is not supported at the machine level; use ipPoolRef or ipPoolRefs")
+	}
+
+	if len(vmCfg.GetIPPoolRefs()) == 0 {
+		errs = append(errs, "spec.vmNetworkConfig requires one of ipPoolRef or ipPoolRefs")
+	}
+
+	if vmCfg.Gateway == "" {
+		errs = append(errs, "spec.vmNetworkConfig.gateway is required")
+	} else if net.ParseIP(vmCfg.Gateway) == nil {
+		errs = append(errs, fmt.Sprintf("spec.vmNetworkConfig.gateway %q is not a valid IP address", vmCfg.Gateway))
+	}
+
+	if vmCfg.SubnetMask == "" {
+		errs = append(errs, "spec.vmNetworkConfig.subnetMask is required")
+	} else if net.ParseIP(vmCfg.SubnetMask) == nil {
+		errs = append(errs, fmt.Sprintf("spec.vmNetworkConfig.subnetMask %q is not a valid IP address", vmCfg.SubnetMask))
+	}
+
+	return errs
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
@@ -326,6 +326,11 @@ func (in *HarvesterMachineSpec) DeepCopyInto(out *HarvesterMachineSpec) {
 	if in.NetworkConfig != nil {
 		in, out := &in.NetworkConfig, &out.NetworkConfig
 		*out = new(NetworkConfig)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.VMNetworkConfig != nil {
+		in, out := &in.VMNetworkConfig, &out.VMNetworkConfig
+		*out = new(VMNetworkConfig)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/api/v1beta1/harvestermachine_types.go
+++ b/api/v1beta1/harvestermachine_types.go
@@ -109,6 +109,19 @@ type HarvesterMachineSpec struct {
 	// If set, this takes precedence over the cluster-level VMNetworkConfig IP pool allocation.
 	// +optional
 	NetworkConfig *NetworkConfig `json:"networkConfig,omitempty"`
+
+	// VMNetworkConfig is the pool-based network configuration for this machine.
+	// When set, it fully replaces the cluster-level spec.vmNetworkConfig of the
+	// HarvesterCluster for this machine: the IP is allocated from the pools
+	// referenced here, and the gateway, subnet mask and DNS settings defined here
+	// are written to the machine cloud-init. Set it in a HarvesterMachineTemplate
+	// to give one machine type (for example the workers) a network configuration
+	// different from the rest of the cluster, such as a dedicated network with its
+	// own gateway. When unset, the cluster-level configuration applies. The inline
+	// ipPool variant is not supported at the machine level; use ipPoolRef or
+	// ipPoolRefs. Mutually exclusive with networkConfig.
+	// +optional
+	VMNetworkConfig *VMNetworkConfig `json:"vmNetworkConfig,omitempty"`
 }
 
 // NetworkConfig defines static network configuration for a VM.

--- a/api/v1beta1/harvestermachine_webhook.go
+++ b/api/v1beta1/harvestermachine_webhook.go
@@ -116,10 +116,49 @@ func validateHarvesterMachine(r *HarvesterMachine) (admission.Warnings, error) {
 		}
 	}
 
+	errs = append(errs, validateMachineVMNetworkConfig(r)...)
+
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("validation failed for HarvesterMachine %s/%s: %s",
 			r.Namespace, r.Name, strings.Join(errs, "; "))
 	}
 
 	return nil, nil
+}
+
+// validateMachineVMNetworkConfig checks the machine-level pool-based network
+// configuration override.
+func validateMachineVMNetworkConfig(r *HarvesterMachine) []string {
+	vmCfg := r.Spec.VMNetworkConfig
+	if vmCfg == nil {
+		return nil
+	}
+
+	var errs []string
+
+	if r.Spec.NetworkConfig != nil {
+		errs = append(errs, "spec.vmNetworkConfig and spec.networkConfig are mutually exclusive")
+	}
+
+	if vmCfg.IPPool != nil {
+		errs = append(errs, "spec.vmNetworkConfig.ipPool is not supported at the machine level; use ipPoolRef or ipPoolRefs")
+	}
+
+	if len(vmCfg.GetIPPoolRefs()) == 0 {
+		errs = append(errs, "spec.vmNetworkConfig requires one of ipPoolRef or ipPoolRefs")
+	}
+
+	if vmCfg.Gateway == "" {
+		errs = append(errs, "spec.vmNetworkConfig.gateway is required")
+	} else if net.ParseIP(vmCfg.Gateway) == nil {
+		errs = append(errs, fmt.Sprintf("spec.vmNetworkConfig.gateway %q is not a valid IP address", vmCfg.Gateway))
+	}
+
+	if vmCfg.SubnetMask == "" {
+		errs = append(errs, "spec.vmNetworkConfig.subnetMask is required")
+	} else if net.ParseIP(vmCfg.SubnetMask) == nil {
+		errs = append(errs, fmt.Sprintf("spec.vmNetworkConfig.subnetMask %q is not a valid IP address", vmCfg.SubnetMask))
+	}
+
+	return errs
 }

--- a/api/v1beta1/harvestermachine_webhook_unit_test.go
+++ b/api/v1beta1/harvestermachine_webhook_unit_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+)
+
+func validMachine() *HarvesterMachine {
+	return &HarvesterMachine{
+		Spec: HarvesterMachineSpec{
+			CPU:        2,
+			Memory:     "4Gi",
+			SSHUser:    "opensuse",
+			SSHKeyPair: "default/ssh-key",
+			Volumes:    []Volume{{VolumeType: "image", ImageName: "default/leap"}},
+			Networks:   []string{"default/workers"},
+		},
+	}
+}
+
+func TestValidateMachineVMNetworkConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(m *HarvesterMachine)
+		wantErr string
+	}{
+		{
+			"valid machine-level config",
+			func(m *HarvesterMachine) {
+				m.Spec.VMNetworkConfig = &VMNetworkConfig{
+					IPPoolRefs: []string{"pool-workers"},
+					Gateway:    "10.20.0.1",
+					SubnetMask: "255.255.255.0",
+				}
+			},
+			"",
+		},
+		{
+			"no pool source",
+			func(m *HarvesterMachine) {
+				m.Spec.VMNetworkConfig = &VMNetworkConfig{
+					Gateway:    "10.20.0.1",
+					SubnetMask: "255.255.255.0",
+				}
+			},
+			"ipPoolRef",
+		},
+		{
+			"inline ipPool is rejected at the machine level",
+			func(m *HarvesterMachine) {
+				m.Spec.VMNetworkConfig = &VMNetworkConfig{
+					IPPool:     &IpPool{VMNetwork: "workers", Subnet: "10.20.0.0/24", Gateway: "10.20.0.1"},
+					Gateway:    "10.20.0.1",
+					SubnetMask: "255.255.255.0",
+				}
+			},
+			"ipPool is not supported",
+		},
+		{
+			"mutually exclusive with static networkConfig",
+			func(m *HarvesterMachine) {
+				m.Spec.NetworkConfig = &NetworkConfig{Address: "10.20.0.10", Gateway: "10.20.0.1"}
+				m.Spec.VMNetworkConfig = &VMNetworkConfig{
+					IPPoolRef:  "pool-workers",
+					Gateway:    "10.20.0.1",
+					SubnetMask: "255.255.255.0",
+				}
+			},
+			"mutually exclusive",
+		},
+		{
+			"invalid gateway",
+			func(m *HarvesterMachine) {
+				m.Spec.VMNetworkConfig = &VMNetworkConfig{
+					IPPoolRef:  "pool-workers",
+					Gateway:    "not-an-ip",
+					SubnetMask: "255.255.255.0",
+				}
+			},
+			"gateway",
+		},
+		{
+			"invalid subnet mask",
+			func(m *HarvesterMachine) {
+				m.Spec.VMNetworkConfig = &VMNetworkConfig{
+					IPPoolRef:  "pool-workers",
+					Gateway:    "10.20.0.1",
+					SubnetMask: "not-a-mask",
+				}
+			},
+			"subnetMask",
+		},
+	}
+	for _, tc := range cases {
+		m := validMachine()
+		tc.mutate(m)
+
+		_, err := validateHarvesterMachine(m)
+
+		if tc.wantErr == "" && err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+
+		if tc.wantErr != "" && err == nil {
+			t.Errorf("%s: expected an error", tc.name)
+		}
+
+		if tc.wantErr != "" && err != nil && !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("%s: error should mention %q: %v", tc.name, tc.wantErr, err)
+		}
+	}
+}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
@@ -326,6 +326,11 @@ func (in *HarvesterMachineSpec) DeepCopyInto(out *HarvesterMachineSpec) {
 	if in.NetworkConfig != nil {
 		in, out := &in.NetworkConfig, &out.NetworkConfig
 		*out = new(NetworkConfig)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.VMNetworkConfig != nil {
+		in, out := &in.VMNetworkConfig, &out.VMNetworkConfig
+		*out = new(VMNetworkConfig)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_harvestermachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_harvestermachines.yaml
@@ -297,6 +297,91 @@ spec:
                 description: SSHUser is the user that should be used to connect to
                   the VMs using SSH.
                 type: string
+              vmNetworkConfig:
+                description: |-
+                  VMNetworkConfig is the pool-based network configuration for this machine.
+                  When set, it fully replaces the cluster-level spec.vmNetworkConfig of the
+                  HarvesterCluster for this machine: the IP is allocated from the pools
+                  referenced here, and the gateway, subnet mask and DNS settings defined here
+                  are written to the machine cloud-init. Set it in a HarvesterMachineTemplate
+                  to give one machine type (for example the workers) a network configuration
+                  different from the rest of the cluster, such as a dedicated network with its
+                  own gateway. When unset, the cluster-level configuration applies. The inline
+                  ipPool variant is not supported at the machine level; use ipPoolRef or
+                  ipPoolRefs. Mutually exclusive with networkConfig.
+                properties:
+                  dnsSearch:
+                    description: DNSSearch is a list of DNS search domains.
+                    items:
+                      type: string
+                    type: array
+                  dnsServers:
+                    description: DNSServers is a list of DNS server IP addresses.
+                    items:
+                      type: string
+                    type: array
+                  gateway:
+                    description: Gateway is the gateway IP address for the VM network.
+                    type: string
+                  ipPool:
+                    description: |-
+                      IPPool defines a new IPPool to create in Harvester for VM IP allocation.
+                      Mutually exclusive with IPPoolRef/IPPoolRefs.
+                    properties:
+                      gateway:
+                        description: |-
+                          Gateway is the IP Address that should be used by the Gateway on the Subnet. It should be a valid address inside the subnet.
+                          e.g. 172.17.1.1.
+                        type: string
+                      rangeEnd:
+                        description: RangeEnd is the last IP Address that should be
+                          used by the IP Pool.
+                        type: string
+                      rangeStart:
+                        description: RangeStart is the first IP Address that should
+                          be used by the IP Pool.
+                        type: string
+                      subnet:
+                        description: |-
+                          Subnet is a string describing the subnet that should be used by the IP Pool, it should have the CIDR Format of an IPv4 Address.
+                          e.g. 172.17.1.0/24.
+                        type: string
+                      vmNetwork:
+                        description: |-
+                          VMNetwork is the name of an existing VM Network in Harvester where the IPPool should exist.
+                          The reference can have the format "namespace/name" or just "name" if the object is in the same namespace as the HarvesterCluster.
+                        type: string
+                    required:
+                    - gateway
+                    - subnet
+                    - vmNetwork
+                    type: object
+                  ipPoolRef:
+                    description: |-
+                      IPPoolRef is a reference to an existing IPPool in Harvester for VM IP allocation.
+                      When multiple pools are needed, use IPPoolRefs instead.
+                      Mutually exclusive with IPPool.
+                    type: string
+                  ipPoolRefs:
+                    description: |-
+                      IPPoolRefs is a list of references to existing IPPools in Harvester.
+                      Pools are tried in order: if a pool is exhausted, allocation falls back
+                      to the next one. A pool whose selector designates a network (the IPPool
+                      spec.selector.network field in Harvester) is only used for machines
+                      attached to that network, so distinct pools can serve, for example, the
+                      control-plane and worker networks of one cluster; a pool with no
+                      selector network is used for any machine.
+                    items:
+                      type: string
+                    type: array
+                  subnetMask:
+                    description: SubnetMask is the subnet mask for the VM network
+                      (e.g. "255.255.0.0").
+                    type: string
+                required:
+                - gateway
+                - subnetMask
+                type: object
               volumes:
                 description: Volumes is a list of Volumes to attach to the VM
                 items:
@@ -1105,6 +1190,91 @@ spec:
                 description: SSHUser is the user that should be used to connect to
                   the VMs using SSH.
                 type: string
+              vmNetworkConfig:
+                description: |-
+                  VMNetworkConfig is the pool-based network configuration for this machine.
+                  When set, it fully replaces the cluster-level spec.vmNetworkConfig of the
+                  HarvesterCluster for this machine: the IP is allocated from the pools
+                  referenced here, and the gateway, subnet mask and DNS settings defined here
+                  are written to the machine cloud-init. Set it in a HarvesterMachineTemplate
+                  to give one machine type (for example the workers) a network configuration
+                  different from the rest of the cluster, such as a dedicated network with its
+                  own gateway. When unset, the cluster-level configuration applies. The inline
+                  ipPool variant is not supported at the machine level; use ipPoolRef or
+                  ipPoolRefs. Mutually exclusive with networkConfig.
+                properties:
+                  dnsSearch:
+                    description: DNSSearch is a list of DNS search domains.
+                    items:
+                      type: string
+                    type: array
+                  dnsServers:
+                    description: DNSServers is a list of DNS server IP addresses.
+                    items:
+                      type: string
+                    type: array
+                  gateway:
+                    description: Gateway is the gateway IP address for the VM network.
+                    type: string
+                  ipPool:
+                    description: |-
+                      IPPool defines a new IPPool to create in Harvester for VM IP allocation.
+                      Mutually exclusive with IPPoolRef/IPPoolRefs.
+                    properties:
+                      gateway:
+                        description: |-
+                          Gateway is the IP Address that should be used by the Gateway on the Subnet. It should be a valid address inside the subnet.
+                          e.g. 172.17.1.1.
+                        type: string
+                      rangeEnd:
+                        description: RangeEnd is the last IP Address that should be
+                          used by the IP Pool.
+                        type: string
+                      rangeStart:
+                        description: RangeStart is the first IP Address that should
+                          be used by the IP Pool.
+                        type: string
+                      subnet:
+                        description: |-
+                          Subnet is a string describing the subnet that should be used by the IP Pool, it should have the CIDR Format of an IPv4 Address.
+                          e.g. 172.17.1.0/24.
+                        type: string
+                      vmNetwork:
+                        description: |-
+                          VMNetwork is the name of an existing VM Network in Harvester where the IPPool should exist.
+                          The reference can have the format "namespace/name" or just "name" if the object is in the same namespace as the HarvesterCluster.
+                        type: string
+                    required:
+                    - gateway
+                    - subnet
+                    - vmNetwork
+                    type: object
+                  ipPoolRef:
+                    description: |-
+                      IPPoolRef is a reference to an existing IPPool in Harvester for VM IP allocation.
+                      When multiple pools are needed, use IPPoolRefs instead.
+                      Mutually exclusive with IPPool.
+                    type: string
+                  ipPoolRefs:
+                    description: |-
+                      IPPoolRefs is a list of references to existing IPPools in Harvester.
+                      Pools are tried in order: if a pool is exhausted, allocation falls back
+                      to the next one. A pool whose selector designates a network (the IPPool
+                      spec.selector.network field in Harvester) is only used for machines
+                      attached to that network, so distinct pools can serve, for example, the
+                      control-plane and worker networks of one cluster; a pool with no
+                      selector network is used for any machine.
+                    items:
+                      type: string
+                    type: array
+                  subnetMask:
+                    description: SubnetMask is the subnet mask for the VM network
+                      (e.g. "255.255.0.0").
+                    type: string
+                required:
+                - gateway
+                - subnetMask
+                type: object
               volumes:
                 description: Volumes is a list of Volumes to attach to the VM
                 items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_harvestermachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_harvestermachinetemplates.yaml
@@ -332,6 +332,92 @@ spec:
                         description: SSHUser is the user that should be used to connect
                           to the VMs using SSH.
                         type: string
+                      vmNetworkConfig:
+                        description: |-
+                          VMNetworkConfig is the pool-based network configuration for this machine.
+                          When set, it fully replaces the cluster-level spec.vmNetworkConfig of the
+                          HarvesterCluster for this machine: the IP is allocated from the pools
+                          referenced here, and the gateway, subnet mask and DNS settings defined here
+                          are written to the machine cloud-init. Set it in a HarvesterMachineTemplate
+                          to give one machine type (for example the workers) a network configuration
+                          different from the rest of the cluster, such as a dedicated network with its
+                          own gateway. When unset, the cluster-level configuration applies. The inline
+                          ipPool variant is not supported at the machine level; use ipPoolRef or
+                          ipPoolRefs. Mutually exclusive with networkConfig.
+                        properties:
+                          dnsSearch:
+                            description: DNSSearch is a list of DNS search domains.
+                            items:
+                              type: string
+                            type: array
+                          dnsServers:
+                            description: DNSServers is a list of DNS server IP addresses.
+                            items:
+                              type: string
+                            type: array
+                          gateway:
+                            description: Gateway is the gateway IP address for the
+                              VM network.
+                            type: string
+                          ipPool:
+                            description: |-
+                              IPPool defines a new IPPool to create in Harvester for VM IP allocation.
+                              Mutually exclusive with IPPoolRef/IPPoolRefs.
+                            properties:
+                              gateway:
+                                description: |-
+                                  Gateway is the IP Address that should be used by the Gateway on the Subnet. It should be a valid address inside the subnet.
+                                  e.g. 172.17.1.1.
+                                type: string
+                              rangeEnd:
+                                description: RangeEnd is the last IP Address that
+                                  should be used by the IP Pool.
+                                type: string
+                              rangeStart:
+                                description: RangeStart is the first IP Address that
+                                  should be used by the IP Pool.
+                                type: string
+                              subnet:
+                                description: |-
+                                  Subnet is a string describing the subnet that should be used by the IP Pool, it should have the CIDR Format of an IPv4 Address.
+                                  e.g. 172.17.1.0/24.
+                                type: string
+                              vmNetwork:
+                                description: |-
+                                  VMNetwork is the name of an existing VM Network in Harvester where the IPPool should exist.
+                                  The reference can have the format "namespace/name" or just "name" if the object is in the same namespace as the HarvesterCluster.
+                                type: string
+                            required:
+                            - gateway
+                            - subnet
+                            - vmNetwork
+                            type: object
+                          ipPoolRef:
+                            description: |-
+                              IPPoolRef is a reference to an existing IPPool in Harvester for VM IP allocation.
+                              When multiple pools are needed, use IPPoolRefs instead.
+                              Mutually exclusive with IPPool.
+                            type: string
+                          ipPoolRefs:
+                            description: |-
+                              IPPoolRefs is a list of references to existing IPPools in Harvester.
+                              Pools are tried in order: if a pool is exhausted, allocation falls back
+                              to the next one. A pool whose selector designates a network (the IPPool
+                              spec.selector.network field in Harvester) is only used for machines
+                              attached to that network, so distinct pools can serve, for example, the
+                              control-plane and worker networks of one cluster; a pool with no
+                              selector network is used for any machine.
+                            items:
+                              type: string
+                            type: array
+                          subnetMask:
+                            description: SubnetMask is the subnet mask for the VM
+                              network (e.g. "255.255.0.0").
+                            type: string
+                        required:
+                        - gateway
+                        - subnetMask
+                        type: object
                       volumes:
                         description: Volumes is a list of Volumes to attach to the
                           VM
@@ -1061,6 +1147,92 @@ spec:
                         description: SSHUser is the user that should be used to connect
                           to the VMs using SSH.
                         type: string
+                      vmNetworkConfig:
+                        description: |-
+                          VMNetworkConfig is the pool-based network configuration for this machine.
+                          When set, it fully replaces the cluster-level spec.vmNetworkConfig of the
+                          HarvesterCluster for this machine: the IP is allocated from the pools
+                          referenced here, and the gateway, subnet mask and DNS settings defined here
+                          are written to the machine cloud-init. Set it in a HarvesterMachineTemplate
+                          to give one machine type (for example the workers) a network configuration
+                          different from the rest of the cluster, such as a dedicated network with its
+                          own gateway. When unset, the cluster-level configuration applies. The inline
+                          ipPool variant is not supported at the machine level; use ipPoolRef or
+                          ipPoolRefs. Mutually exclusive with networkConfig.
+                        properties:
+                          dnsSearch:
+                            description: DNSSearch is a list of DNS search domains.
+                            items:
+                              type: string
+                            type: array
+                          dnsServers:
+                            description: DNSServers is a list of DNS server IP addresses.
+                            items:
+                              type: string
+                            type: array
+                          gateway:
+                            description: Gateway is the gateway IP address for the
+                              VM network.
+                            type: string
+                          ipPool:
+                            description: |-
+                              IPPool defines a new IPPool to create in Harvester for VM IP allocation.
+                              Mutually exclusive with IPPoolRef/IPPoolRefs.
+                            properties:
+                              gateway:
+                                description: |-
+                                  Gateway is the IP Address that should be used by the Gateway on the Subnet. It should be a valid address inside the subnet.
+                                  e.g. 172.17.1.1.
+                                type: string
+                              rangeEnd:
+                                description: RangeEnd is the last IP Address that
+                                  should be used by the IP Pool.
+                                type: string
+                              rangeStart:
+                                description: RangeStart is the first IP Address that
+                                  should be used by the IP Pool.
+                                type: string
+                              subnet:
+                                description: |-
+                                  Subnet is a string describing the subnet that should be used by the IP Pool, it should have the CIDR Format of an IPv4 Address.
+                                  e.g. 172.17.1.0/24.
+                                type: string
+                              vmNetwork:
+                                description: |-
+                                  VMNetwork is the name of an existing VM Network in Harvester where the IPPool should exist.
+                                  The reference can have the format "namespace/name" or just "name" if the object is in the same namespace as the HarvesterCluster.
+                                type: string
+                            required:
+                            - gateway
+                            - subnet
+                            - vmNetwork
+                            type: object
+                          ipPoolRef:
+                            description: |-
+                              IPPoolRef is a reference to an existing IPPool in Harvester for VM IP allocation.
+                              When multiple pools are needed, use IPPoolRefs instead.
+                              Mutually exclusive with IPPool.
+                            type: string
+                          ipPoolRefs:
+                            description: |-
+                              IPPoolRefs is a list of references to existing IPPools in Harvester.
+                              Pools are tried in order: if a pool is exhausted, allocation falls back
+                              to the next one. A pool whose selector designates a network (the IPPool
+                              spec.selector.network field in Harvester) is only used for machines
+                              attached to that network, so distinct pools can serve, for example, the
+                              control-plane and worker networks of one cluster; a pool with no
+                              selector network is used for any machine.
+                            items:
+                              type: string
+                            type: array
+                          subnetMask:
+                            description: SubnetMask is the subnet mask for the VM
+                              network (e.g. "255.255.0.0").
+                            type: string
+                        required:
+                        - gateway
+                        - subnetMask
+                        type: object
                       volumes:
                         description: Volumes is a list of Volumes to attach to the
                           VM

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -960,6 +960,46 @@ template attached to `default/net-workers`, each machine allocates from the pool
 own network. If no listed pool matches a machine's networks, allocation fails with an explicit
 error rather than handing out an address from another network.
 
+### Per machine type network configuration
+
+Network-aware selection picks the right pool, but the cluster-level `vmNetworkConfig` still
+carries a single `gateway`, `subnetMask` and DNS set for every machine. When the control-plane
+and worker networks are different subnets (for example to comply with the German BSI
+APP.4.4.A7 requirement of separate control-plane and worker networks), set `vmNetworkConfig`
+directly in the HarvesterMachineTemplate of the machine type that lives in the other subnet:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HarvesterMachineTemplate
+metadata:
+  name: workers
+spec:
+  template:
+    spec:
+      networks:
+        - "default/net-workers"
+      vmNetworkConfig:
+        ipPoolRefs:
+          - "pool-workers"
+        gateway: "10.20.0.1"
+        subnetMask: "255.255.255.0"
+        dnsServers:
+          - "10.20.0.53"
+      # cpu, memory, volumes, ...
+```
+
+A machine-level `vmNetworkConfig` fully replaces the cluster-level one for the machines
+created from that template: IP allocation uses the pools referenced here and the cloud-init
+static network configuration uses this gateway, subnet mask and DNS. Machine types without it
+(for example the control-plane template) keep using the cluster-level configuration, so the
+override is fully backward compatible. Notes:
+
+- The machine-level variant only accepts pool references (`ipPoolRef` or `ipPoolRefs`);
+  the inline `ipPool` definition stays cluster-level.
+- `vmNetworkConfig` and the static per-machine `networkConfig` are mutually exclusive on
+  the same machine.
+- Network-aware selection applies to the machine-level pool list as well.
+
 ### CLI usage
 
 ```bash

--- a/internal/controller/harvestermachine_controller.go
+++ b/internal/controller/harvestermachine_controller.go
@@ -332,8 +332,10 @@ func (r *HarvesterMachineReconciler) ReconcileNormal(hvScope *Scope) (res reconc
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 
-	// Resolve effective network config: cluster-level pool allocation or machine-level static config
-	if hvScope.HarvesterCluster.Spec.VMNetworkConfig != nil && hvScope.HarvesterMachine.Spec.NetworkConfig == nil {
+	// Resolve effective network config: pool allocation (machine-level
+	// vmNetworkConfig taking precedence over the cluster-level one) or
+	// machine-level static config
+	if effectiveVMNetworkConfig(hvScope) != nil && hvScope.HarvesterMachine.Spec.NetworkConfig == nil {
 		// Allocate IP from cluster-level VM IP pool
 		allocErr := r.allocateVMIP(hvScope)
 		if allocErr != nil {
@@ -349,7 +351,7 @@ func (r *HarvesterMachineReconciler) ReconcileNormal(hvScope *Scope) (res reconc
 			return ctrl.Result{RequeueAfter: requeueTimeShort}, allocErr
 		}
 
-		vmNetCfg := hvScope.HarvesterCluster.Spec.VMNetworkConfig
+		vmNetCfg := effectiveVMNetworkConfig(hvScope)
 		hvScope.EffectiveNetworkConfig = &infrav1.NetworkConfig{
 			Address:    hvScope.HarvesterMachine.Status.AllocatedIPAddress,
 			Gateway:    vmNetCfg.Gateway,
@@ -1106,8 +1108,8 @@ func buildNetworkDataStatic(hvScope *Scope) string {
 	netCfg := hvScope.EffectiveNetworkConfig
 	subnetMask := "255.255.0.0" // default
 
-	if hvScope.HarvesterCluster.Spec.VMNetworkConfig != nil {
-		subnetMask = hvScope.HarvesterCluster.Spec.VMNetworkConfig.SubnetMask
+	if vmNetCfg := effectiveVMNetworkConfig(hvScope); vmNetCfg != nil {
+		subnetMask = vmNetCfg.SubnetMask
 	}
 
 	b.WriteString("version: 1\nconfig:\n")
@@ -1287,7 +1289,21 @@ func getCloudInitData(hvScope *Scope) (string, error) {
 	return string(userData), nil
 }
 
-// allocateVMIP allocates an IP from the cluster-level VM IP pool for this machine.
+// effectiveVMNetworkConfig returns the pool-based network configuration that
+// applies to the machine: the machine-level spec.vmNetworkConfig when set,
+// otherwise the cluster-level one from the HarvesterCluster.
+//
+//nolint:funcorder
+func effectiveVMNetworkConfig(hvScope *Scope) *infrav1.VMNetworkConfig {
+	if hvScope.HarvesterMachine.Spec.VMNetworkConfig != nil {
+		return hvScope.HarvesterMachine.Spec.VMNetworkConfig
+	}
+
+	return hvScope.HarvesterCluster.Spec.VMNetworkConfig
+}
+
+// allocateVMIP allocates an IP from the effective VM IP pool configuration
+// (machine-level or cluster-level) for this machine.
 // It is idempotent: if an IP is already allocated, it returns early.
 //
 //nolint:funcorder
@@ -1302,9 +1318,9 @@ func (r *HarvesterMachineReconciler) allocateVMIP(hvScope *Scope) error {
 		return nil
 	}
 
-	vmNetCfg := hvScope.HarvesterCluster.Spec.VMNetworkConfig
+	vmNetCfg := effectiveVMNetworkConfig(hvScope)
 	if vmNetCfg == nil {
-		return errors.New("VMNetworkConfig is nil on HarvesterCluster")
+		return errors.New("VMNetworkConfig is nil on both the HarvesterMachine and the HarvesterCluster")
 	}
 
 	poolRefs := vmNetCfg.GetIPPoolRefs()
@@ -1407,7 +1423,7 @@ func (r *HarvesterMachineReconciler) releaseVMIP(hvScope *Scope) {
 
 	// Determine which pool to release from: use AllocatedPoolRef if available,
 	// fall back to first configured pool for backward compatibility.
-	vmNetCfg := hvScope.HarvesterCluster.Spec.VMNetworkConfig
+	vmNetCfg := effectiveVMNetworkConfig(hvScope)
 
 	poolRef := machine.Status.AllocatedPoolRef
 	if poolRef == "" && vmNetCfg != nil {

--- a/internal/controller/machine_level_vmnetworkconfig_test.go
+++ b/internal/controller/machine_level_vmnetworkconfig_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025 SUSE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	lbv1beta1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1 "github.com/rancher-sandbox/cluster-api-provider-harvester/api/v1beta1"
+	hvfake "github.com/rancher-sandbox/cluster-api-provider-harvester/pkg/clientset/versioned/fake"
+)
+
+// =============================================================================
+// Tests for the machine-level VMNetworkConfig override (per machine type
+// network configuration, issue #234)
+// =============================================================================
+
+var _ = Describe("effectiveVMNetworkConfig", func() {
+	It("should return the machine-level config when set", func() {
+		machineCfg := &infrav1.VMNetworkConfig{IPPoolRef: "pool-workers", Gateway: "10.20.0.1", SubnetMask: "255.255.255.0"}
+		clusterCfg := &infrav1.VMNetworkConfig{IPPoolRef: "capi-vm-pool", Gateway: "172.16.0.1", SubnetMask: "255.255.0.0"}
+
+		scope := &Scope{
+			HarvesterMachine: &infrav1.HarvesterMachine{
+				Spec: infrav1.HarvesterMachineSpec{VMNetworkConfig: machineCfg},
+			},
+			HarvesterCluster: &infrav1.HarvesterCluster{
+				Spec: infrav1.HarvesterClusterSpec{VMNetworkConfig: clusterCfg},
+			},
+		}
+
+		Expect(effectiveVMNetworkConfig(scope)).To(BeIdenticalTo(machineCfg))
+	})
+
+	It("should fall back to the cluster-level config when the machine has none", func() {
+		clusterCfg := &infrav1.VMNetworkConfig{IPPoolRef: "capi-vm-pool", Gateway: "172.16.0.1", SubnetMask: "255.255.0.0"}
+
+		scope := &Scope{
+			HarvesterMachine: &infrav1.HarvesterMachine{},
+			HarvesterCluster: &infrav1.HarvesterCluster{
+				Spec: infrav1.HarvesterClusterSpec{VMNetworkConfig: clusterCfg},
+			},
+		}
+
+		Expect(effectiveVMNetworkConfig(scope)).To(BeIdenticalTo(clusterCfg))
+	})
+
+	It("should return nil when neither level has a config", func() {
+		scope := &Scope{
+			HarvesterMachine: &infrav1.HarvesterMachine{},
+			HarvesterCluster: &infrav1.HarvesterCluster{},
+		}
+
+		Expect(effectiveVMNetworkConfig(scope)).To(BeNil())
+	})
+})
+
+var _ = Describe("allocateVMIP with machine-level VMNetworkConfig", func() {
+	var clusterPool *lbv1beta1.IPPool
+
+	var workerPool *lbv1beta1.IPPool
+
+	BeforeEach(func() {
+		clusterPool = &lbv1beta1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "capi-vm-pool"},
+			Spec: lbv1beta1.IPPoolSpec{
+				Ranges: []lbv1beta1.Range{
+					{RangeStart: "172.16.3.40", RangeEnd: "172.16.3.49", Subnet: "172.16.0.0/16", Gateway: "172.16.0.1"},
+				},
+			},
+			Status: lbv1beta1.IPPoolStatus{},
+		}
+		workerPool = &lbv1beta1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "pool-workers"},
+			Spec: lbv1beta1.IPPoolSpec{
+				Ranges: []lbv1beta1.Range{
+					{RangeStart: "10.20.0.10", RangeEnd: "10.20.0.19", Subnet: "10.20.0.0/24", Gateway: "10.20.0.1"},
+				},
+			},
+			Status: lbv1beta1.IPPoolStatus{},
+		}
+	})
+
+	It("should allocate from the machine-level pools instead of the cluster-level ones", func() {
+		hvClient := hvfake.NewSimpleClientset(clusterPool, workerPool)
+		logger := log.FromContext(context.TODO())
+
+		scope := &Scope{
+			HarvesterMachine: &infrav1.HarvesterMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0", Namespace: "test-ns"},
+				Spec: infrav1.HarvesterMachineSpec{
+					VMNetworkConfig: &infrav1.VMNetworkConfig{
+						IPPoolRefs: []string{"pool-workers"},
+						Gateway:    "10.20.0.1",
+						SubnetMask: "255.255.255.0",
+					},
+				},
+			},
+			HarvesterCluster: &infrav1.HarvesterCluster{
+				Spec: infrav1.HarvesterClusterSpec{
+					VMNetworkConfig: &infrav1.VMNetworkConfig{
+						IPPoolRef: "capi-vm-pool",
+					},
+				},
+			},
+			HarvesterClient: hvClient,
+			Logger:          &logger,
+		}
+
+		r := &HarvesterMachineReconciler{}
+		err := r.allocateVMIP(scope)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(scope.HarvesterMachine.Status.AllocatedPoolRef).To(Equal("pool-workers"))
+		Expect(scope.HarvesterMachine.Status.AllocatedIPAddress).To(HavePrefix("10.20.0."))
+	})
+
+	It("should allocate even when the HarvesterCluster has no VMNetworkConfig", func() {
+		hvClient := hvfake.NewSimpleClientset(workerPool)
+		logger := log.FromContext(context.TODO())
+
+		scope := &Scope{
+			HarvesterMachine: &infrav1.HarvesterMachine{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-worker-1", Namespace: "test-ns"},
+				Spec: infrav1.HarvesterMachineSpec{
+					VMNetworkConfig: &infrav1.VMNetworkConfig{
+						IPPoolRef:  "pool-workers",
+						Gateway:    "10.20.0.1",
+						SubnetMask: "255.255.255.0",
+					},
+				},
+			},
+			HarvesterCluster: &infrav1.HarvesterCluster{},
+			HarvesterClient:  hvClient,
+			Logger:           &logger,
+		}
+
+		r := &HarvesterMachineReconciler{}
+		err := r.allocateVMIP(scope)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(scope.HarvesterMachine.Status.AllocatedPoolRef).To(Equal("pool-workers"))
+		Expect(scope.HarvesterMachine.Status.AllocatedIPAddress).To(HavePrefix("10.20.0."))
+	})
+})
+
+var _ = Describe("buildNetworkDataStatic with machine-level VMNetworkConfig", func() {
+	It("should use the machine-level subnet mask instead of the cluster-level one", func() {
+		scope := &Scope{
+			HarvesterMachine: &infrav1.HarvesterMachine{
+				Spec: infrav1.HarvesterMachineSpec{
+					Networks: []string{"default/workers"},
+					VMNetworkConfig: &infrav1.VMNetworkConfig{
+						IPPoolRef:  "pool-workers",
+						Gateway:    "10.20.0.1",
+						SubnetMask: "255.255.255.0",
+						DNSServers: []string{"10.20.0.53"},
+					},
+				},
+			},
+			HarvesterCluster: &infrav1.HarvesterCluster{
+				Spec: infrav1.HarvesterClusterSpec{
+					VMNetworkConfig: &infrav1.VMNetworkConfig{
+						SubnetMask: "255.255.0.0",
+						Gateway:    "172.16.0.1",
+						DNSServers: []string{"172.16.0.1"},
+					},
+				},
+			},
+			EffectiveNetworkConfig: &infrav1.NetworkConfig{
+				Address:    "10.20.0.10",
+				Gateway:    "10.20.0.1",
+				DNSServers: []string{"10.20.0.53"},
+			},
+		}
+
+		result := buildNetworkDataStatic(scope)
+		Expect(result).To(ContainSubstring("netmask: 255.255.255.0"))
+		Expect(result).ToNot(ContainSubstring("netmask: 255.255.0.0"))
+		Expect(result).To(ContainSubstring("address: 10.20.0.10"))
+		Expect(result).To(ContainSubstring("gateway: 10.20.0.1"))
+		Expect(result).To(ContainSubstring("- 10.20.0.53"))
+	})
+})

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 0
+    minor: 7
+    contract: v1beta2
+  - major: 0
     minor: 6
     contract: v1beta2
   - major: 0


### PR DESCRIPTION
## Summary

Implements the second half of #234: a machine-level `vmNetworkConfig` for per machine type network configuration.

- `spec.vmNetworkConfig` can now be set on a `HarvesterMachine`, typically through a `HarvesterMachineTemplate`, and fully replaces the cluster-level configuration for the machines created from that template: IP allocation uses the pools referenced there, and the cloud-init static network configuration uses its gateway, subnet mask and DNS settings.
- Machine types without the override keep the cluster-level behavior, so existing clusters are unaffected.
- The machine-level variant accepts pool references only (`ipPoolRef` or `ipPoolRefs`, no inline `ipPool`) and is mutually exclusive with the static per-machine `networkConfig`; both rules are enforced by the HarvesterMachine validating webhook (v1beta1 and v1alpha1).
- Combined with the network-aware pool selection shipped in v0.6.1 (#235), this covers the separate control-plane and worker networks scenario (BSI APP.4.4.A7) as well as finer worker segmentation (for example dedicated ingress workers).
- The field exists in both API versions and converts losslessly (covered by the conversion fuzz round-trip).
- `metadata.yaml` declares the 0.7 release series.
- `docs/operations.md` documents the override with a two-network example.

## Validation

Unit tests (all green, plus lint):

- effective configuration resolution (machine-level wins, cluster-level fallback, nil when neither is set)
- allocation from the machine-level pools with a fake Harvester client, including when the HarvesterCluster has no `vmNetworkConfig` at all
- cloud-init network data generated with the machine-level subnet mask instead of the cluster-level one
- webhook rules (pool source required, inline `ipPool` rejected, mutual exclusion with `networkConfig`, gateway and subnet mask validation)
- conversion fuzz round-trip covering the new field in both directions

Functional run against a real Harvester 1.8.0 (Turtles `CreateUsingGitOpsSpec` suite, RC image built from this branch): a test-only ClusterClass patch set a machine-level `vmNetworkConfig` on the worker template only (dedicated pool `pool-workers` 172.16.3.60-64 with a network selector, a /22 subnet mask and an extra DNS server as marker), while the control plane kept the cluster-level configuration (`capi-vm-pool` 172.16.3.40-49). Result: suite SUCCESS (full provisioning, Rancher import, deletion). The worker machine allocated its address from `pool-workers` and its cloud-init carried the override (subnet mask and DNS marker), the control-plane machine allocated from `capi-vm-pool` with the cluster-level settings, and both pools released their addresses cleanly on deletion.

Fixes #234
