### PR TITLE
feat: CIS hardening switch in the ClusterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **CIS hardening switch in the ClusterClass**: the new `cisProfile` topology
+  variable enables the RKE2 CIS profile on every node of the cluster and
+  injects the node prerequisites the hardened kubelet requires (the `etcd`
+  system user and the protect-kernel-defaults sysctls) through
+  `preRKE2Commands`. Empty by default: existing clusters are unaffected.
+  The certification suite gains the matching `CIS_PROFILE` knob.
+
 ## [v0.9.0] - 2026-07-28
 
 ### Added

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -62,19 +62,24 @@ dedicated hardening mode: setting `profile: cis` in the RKE2 server
 configuration enforces the benchmark's kernel parameters, applies restrictive
 Pod Security Standards and refuses to start on non-compliant nodes.
 
-With CAPHV today:
+With the shipped ClusterClass this is a single switch: set the `cisProfile`
+topology variable (`cis`, or a versioned profile such as `cis-1.23`):
 
-- enable the profile in the `RKE2ControlPlaneTemplate`
-  (`spec.template.spec.serverConfig.cis`) and in the worker
-  `RKE2ConfigTemplate`;
-- the profile requires node prerequisites (the `etcd` system user and the
-  `vm.panic_on_oom`, `vm.overcommit_memory` and `kernel.panic*` sysctls);
-  provide them through the bootstrap provider's additional cloud-init until
-  the ClusterClass exposes a dedicated variable.
+```yaml
+spec:
+  topology:
+    variables:
+      - name: cisProfile
+        value: "cis"
+```
 
-Making this a single ClusterClass switch (profile flag plus node prerequisites
-injected automatically) is planned work; this section will be updated when it
-lands.
+The profile is then enabled on the control plane and the workers
+(`agentConfig.cisProfile` on the RKE2 templates), and the node prerequisites
+the hardened kubelet requires are injected automatically through
+`preRKE2Commands`: the `etcd` system user and the protect-kernel-defaults
+sysctls (`vm.panic_on_oom=0`, `vm.overcommit_memory=1`, `kernel.panic=10`,
+`kernel.panic_on_oops=1`). Clusters built without ClusterClass can replicate
+this by setting the same two fields in their RKE2 templates.
 
 ## DISA STIG
 

--- a/templates/clusterclass/rke2/clusterclass-harvester-rke2.yaml
+++ b/templates/clusterclass/rke2/clusterclass-harvester-rke2.yaml
@@ -170,6 +170,15 @@ spec:
           type: string
           default: "calico"
           description: "CNI plugin (calico, canal, cilium, none)"
+    # RKE2 CIS hardening profile
+    - name: cisProfile
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+          enum: ["", "cis", "cis-1.23", "cis-1.5", "cis-1.6"]
+          description: "RKE2 CIS profile. When set, the profile is enabled on every node and the node prerequisites (etcd user, protect-kernel-defaults sysctls) are injected automatically. Empty disables hardening."
   # --- Patches ---
   patches:
     # Patch VM networks on both CP and worker HarvesterMachineTemplates
@@ -395,6 +404,90 @@ spec:
               path: /spec/template/spec/serverConfig/cni
               valueFrom:
                 variable: cni
+    # Enable the RKE2 CIS profile and inject its node prerequisites: the etcd
+    # system user and the protect-kernel-defaults sysctls the hardened kubelet
+    # requires. The sysctls are written directly (the rke2-cis-sysctl.conf
+    # shipped with RKE2 does not exist yet when preRKE2Commands run).
+    - name: cisProfile
+      enabledIf: '{{ if .cisProfile }}true{{ end }}'
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: RKE2ControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/agentConfig
+              valueFrom:
+                template: |
+                  cisProfile: {{ .cisProfile }}
+                  podSecurityAdmissionConfigFile: /etc/rancher/rke2/rancher-pss.yaml
+            - op: add
+              path: /spec/template/spec/files
+              value:
+                - path: /etc/rancher/rke2/rancher-pss.yaml
+                  owner: root:root
+                  permissions: "0600"
+                  content: |
+                    apiVersion: apiserver.config.k8s.io/v1
+                    kind: AdmissionConfiguration
+                    plugins:
+                      - name: PodSecurity
+                        configuration:
+                          apiVersion: pod-security.admission.config.k8s.io/v1
+                          kind: PodSecurityConfiguration
+                          defaults:
+                            enforce: "restricted"
+                            enforce-version: "latest"
+                            audit: "restricted"
+                            audit-version: "latest"
+                            warn: "restricted"
+                            warn-version: "latest"
+                          exemptions:
+                            usernames: []
+                            runtimeClasses: []
+                            namespaces:
+                              - kube-system
+                              - cis-operator-system
+                              - tigera-operator
+                              - calico-system
+                              - cattle-system
+                              - cattle-fleet-system
+                              - cattle-fleet-local-system
+                              - cattle-impersonation-system
+                              - cattle-monitoring-system
+                              - cattle-provisioning-capi-system
+                              - cattle-resources-system
+                              - cattle-ui-plugin-system
+                              - fleet-default
+                              - longhorn-system
+                              - ingress-nginx
+            - op: add
+              path: /spec/template/spec/preRKE2Commands
+              value:
+                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                - sysctl -p /etc/sysctl.d/90-kubelet.conf
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: RKE2ConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/agentConfig
+              valueFrom:
+                template: |
+                  cisProfile: {{ .cisProfile }}
+            - op: add
+              path: /spec/template/spec/preRKE2Commands
+              value:
+                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                - sysctl -p /etc/sysctl.d/90-kubelet.conf
     # Patch CSI addon ConfigMap name (per-cluster)
     - name: csiAddonConfigMap
       definitions:

--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -82,3 +82,4 @@ variables:
   IP_POOL_REF: "capi-vm-pool"
   DNS_SERVERS: "172.16.0.1"
   CNI: "calico"
+  CIS_PROFILE: ""

--- a/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
+++ b/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
@@ -133,6 +133,13 @@ spec:
         openAPIV3Schema:
           type: string
           default: "calico"
+    - name: cisProfile
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
+          enum: ["", "cis", "cis-1.23", "cis-1.5", "cis-1.6"]
   patches:
     - name: vmNetworks
       definitions:
@@ -344,6 +351,86 @@ spec:
               path: /spec/template/spec/serverConfig/cni
               valueFrom:
                 variable: cni
+    - name: cisProfile
+      enabledIf: '{{ if .cisProfile }}true{{ end }}'
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: RKE2ControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/agentConfig
+              valueFrom:
+                template: |
+                  cisProfile: {{ .cisProfile }}
+                  podSecurityAdmissionConfigFile: /etc/rancher/rke2/rancher-pss.yaml
+            - op: add
+              path: /spec/template/spec/files
+              value:
+                - path: /etc/rancher/rke2/rancher-pss.yaml
+                  owner: root:root
+                  permissions: "0600"
+                  content: |
+                    apiVersion: apiserver.config.k8s.io/v1
+                    kind: AdmissionConfiguration
+                    plugins:
+                      - name: PodSecurity
+                        configuration:
+                          apiVersion: pod-security.admission.config.k8s.io/v1
+                          kind: PodSecurityConfiguration
+                          defaults:
+                            enforce: "restricted"
+                            enforce-version: "latest"
+                            audit: "restricted"
+                            audit-version: "latest"
+                            warn: "restricted"
+                            warn-version: "latest"
+                          exemptions:
+                            usernames: []
+                            runtimeClasses: []
+                            namespaces:
+                              - kube-system
+                              - cis-operator-system
+                              - tigera-operator
+                              - calico-system
+                              - cattle-system
+                              - cattle-fleet-system
+                              - cattle-fleet-local-system
+                              - cattle-impersonation-system
+                              - cattle-monitoring-system
+                              - cattle-provisioning-capi-system
+                              - cattle-resources-system
+                              - cattle-ui-plugin-system
+                              - fleet-default
+                              - longhorn-system
+                              - ingress-nginx
+            - op: add
+              path: /spec/template/spec/preRKE2Commands
+              value:
+                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                - sysctl -p /etc/sysctl.d/90-kubelet.conf
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: RKE2ConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/agentConfig
+              valueFrom:
+                template: |
+                  cisProfile: {{ .cisProfile }}
+            - op: add
+              path: /spec/template/spec/preRKE2Commands
+              value:
+                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                - sysctl -p /etc/sysctl.d/90-kubelet.conf
     - name: csiAddonConfigMap
       definitions:
         - selector:
@@ -532,6 +619,8 @@ spec:
           - "${DNS_SERVERS}"
       - name: cni
         value: "${CNI}"
+      - name: cisProfile
+        value: "${CIS_PROFILE}"
 ---
 # ClusterResourceSet — CSI plugin DaemonSet + RBAC
 apiVersion: addons.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
## Summary

Adds a one-switch CIS hardening option to the shipped ClusterClass, as announced in `docs/compliance.md`.

- New `cisProfile` topology variable (`cis`, `cis-1.23`, `cis-1.5`, `cis-1.6`; empty by default so existing clusters are unaffected). When set:
  - `agentConfig.cisProfile` is applied to the control plane and the worker RKE2 templates;
  - the node prerequisites the hardened kubelet requires (the `etcd` system user and the protect-kernel-defaults sysctls) are injected through `preRKE2Commands`. The bootstrap provider also generates its own CIS prerequisite script after the RKE2 install; the injected commands keep the node compliant even if that later stage is interrupted, and both are idempotent;
  - the control plane receives a pod security admission configuration file keeping `restricted` as the cluster default while exempting the documented Rancher, CNI and storage system namespaces. Without it the hardened cluster cannot be imported: the default enforcement rejects the `cattle-cluster-agent` pod in `cattle-system` and the Rancher import never completes (observed live before the fix).
- The certification suite gains the matching `CIS_PROFILE` knob (empty default), and `docs/compliance.md` now documents the switch as available.

## Validation

Functional run of the Turtles `CreateUsingGitOpsSpec` suite against a real Harvester 1.8.0 with `CIS_PROFILE=cis` and the released CAPHV v0.9.0: SUCCESS (full provisioning, Rancher import, deletion). Live evidence collected during the run:

- a privileged probe pod in the `default` namespace is rejected with `violates PodSecurity "restricted:latest"`, proving the hardening is effective outside the exempted namespaces;
- the `cattle-cluster-agent` starts normally in the exempted `cattle-system` namespace and the Rancher import completes;
- both nodes reach `Ready` with the profile active; RKE2 refuses to start when the prerequisites are missing, so a green run also proves the injected prerequisites work;
- the worker guest was inspected through the qemu guest agent during the run: `rke2-agent` healthy, standard image pulls, clean join.

One timing observation for CI: hardening shifts the whole bring-up (later MachineDeployment start, image pulls inside the fixed 5 minute `VerifyClusterAvailable` window of the upstream spec), so the check passes with only a couple of minutes of margin on this lab.
