### PR TITLE
feat: FIPS enforcement switch in the ClusterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- **FIPS enforcement switch in the ClusterClass**: the new `fipsRequired`
+  topology variable (default `false`) injects a bootstrap guard that refuses
+  to start a node whose image does not run in FIPS mode
+  (`/proc/sys/crypto/fips_enabled`), so FIPS clusters cannot silently run on
+  non-FIPS images. FIPS mode itself comes from the node image; the compliance
+  guide documents the image build recipe. The certification suite gains the
+  matching `FIPS_REQUIRED` knob, and the CIS and FIPS node preparation
+  commands now compose in a single patch.
 - **STIG-hardened cluster template flavor** (`cluster-template-stig.yaml`):
   a ready-to-use flavor aligning the RKE2 side of the cluster with the DISA
   RKE2 STIG guidance: CIS profile with injected node prerequisites, audit

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -105,13 +105,23 @@ image (`VM_IMAGE_NAME`) to cover the OS layer.
 
 ## FIPS 140
 
-- SLES nodes can run in FIPS mode (kernel `fips=1` plus the `fips` pattern);
-  this is an image or cloud-init concern on the node layer.
+FIPS mode is a boot-time property of the node image (kernel parameter plus the
+FIPS pattern); it cannot be turned on by cloud-init without a reboot, so CAPHV
+does not pretend to enable it. The split is:
+
+- **Build a FIPS node image** once: boot the standard SLES or openSUSE cloud
+  image, run `zypper -n in -t pattern fips`, add `fips=1` to
+  `GRUB_CMDLINE_LINUX_DEFAULT` (`grub2-mkconfig -o /boot/grub2/grub.cfg`),
+  regenerate the initrd (`dracut -f`), run `cloud-init clean --logs`, stop the
+  VM and export its volume as a Harvester image
+  (`VirtualMachineImage` with `sourceType: export-from-volume`). Reference the
+  image in `volumes[].imageName`.
+- **Enforce it from the cluster definition**: the `fipsRequired` topology
+  variable of the shipped ClusterClass (default `false`) injects a guard into
+  the node bootstrap that fails unless `/proc/sys/crypto/fips_enabled` is `1`,
+  so a cluster that must be FIPS can never silently run on a non-FIPS image.
 - RKE2 is available in FIPS-validated builds for government use; select the
   matching RKE2 version in the cluster definition.
-- CAPHV itself performs no workload cryptography: node-level FIPS enablement
-  is what matters, and a convenience knob to turn it on from the machine
-  template is planned.
 
 ## ANSSI (France)
 

--- a/templates/clusterclass/rke2/clusterclass-harvester-rke2.yaml
+++ b/templates/clusterclass/rke2/clusterclass-harvester-rke2.yaml
@@ -179,6 +179,14 @@ spec:
           default: ""
           enum: ["", "cis", "cis-1.23", "cis-1.5", "cis-1.6"]
           description: "RKE2 CIS profile. When set, the profile is enabled on every node and the node prerequisites (etcd user, protect-kernel-defaults sysctls) are injected automatically. Empty disables hardening."
+    # Refuse to bootstrap nodes whose image does not run in FIPS mode
+    - name: fipsRequired
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: boolean
+          default: false
+          description: "When true, node bootstrap fails unless the node image runs in FIPS mode (/proc/sys/crypto/fips_enabled is 1). FIPS mode itself comes from the node image; see docs/compliance.md."
   # --- Patches ---
   patches:
     # Patch VM networks on both CP and worker HarvesterMachineTemplates
@@ -463,12 +471,6 @@ spec:
                               - fleet-default
                               - longhorn-system
                               - ingress-nginx
-            - op: add
-              path: /spec/template/spec/preRKE2Commands
-              value:
-                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
-                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
-                - sysctl -p /etc/sysctl.d/90-kubelet.conf
         - selector:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: RKE2ConfigTemplate
@@ -482,13 +484,42 @@ spec:
               valueFrom:
                 template: |
                   cisProfile: {{ .cisProfile }}
+    # Patch CSI addon ConfigMap name (per-cluster)
+    - name: nodePreparation
+      enabledIf: '{{ if or .cisProfile .fipsRequired }}true{{ end }}'
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: RKE2ControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
             - op: add
               path: /spec/template/spec/preRKE2Commands
-              value:
-                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
-                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
-                - sysctl -p /etc/sysctl.d/90-kubelet.conf
-    # Patch CSI addon ConfigMap name (per-cluster)
+              valueFrom:
+                template: |
+                  {{ if .fipsRequired }}- test "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" || { echo "FIPS mode required but not enabled on this node image" >&2; exit 1; }
+                  {{ end }}{{ if .cisProfile }}- useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                  - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                  - sysctl -p /etc/sysctl.d/90-kubelet.conf
+                  {{ end }}
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: RKE2ConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/preRKE2Commands
+              valueFrom:
+                template: |
+                  {{ if .fipsRequired }}- test "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" || { echo "FIPS mode required but not enabled on this node image" >&2; exit 1; }
+                  {{ end }}{{ if .cisProfile }}- useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                  - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                  - sysctl -p /etc/sysctl.d/90-kubelet.conf
+                  {{ end }}
     - name: csiAddonConfigMap
       definitions:
         - selector:

--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -83,3 +83,4 @@ variables:
   DNS_SERVERS: "172.16.0.1"
   CNI: "calico"
   CIS_PROFILE: ""
+  FIPS_REQUIRED: "false"

--- a/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
+++ b/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
@@ -140,6 +140,12 @@ spec:
           type: string
           default: ""
           enum: ["", "cis", "cis-1.23", "cis-1.5", "cis-1.6"]
+    - name: fipsRequired
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: boolean
+          default: false
   patches:
     - name: vmNetworks
       definitions:
@@ -406,12 +412,6 @@ spec:
                               - fleet-default
                               - longhorn-system
                               - ingress-nginx
-            - op: add
-              path: /spec/template/spec/preRKE2Commands
-              value:
-                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
-                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
-                - sysctl -p /etc/sysctl.d/90-kubelet.conf
         - selector:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: RKE2ConfigTemplate
@@ -425,12 +425,41 @@ spec:
               valueFrom:
                 template: |
                   cisProfile: {{ .cisProfile }}
+    - name: nodePreparation
+      enabledIf: '{{ if or .cisProfile .fipsRequired }}true{{ end }}'
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: RKE2ControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
             - op: add
               path: /spec/template/spec/preRKE2Commands
-              value:
-                - useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
-                - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
-                - sysctl -p /etc/sysctl.d/90-kubelet.conf
+              valueFrom:
+                template: |
+                  {{ if .fipsRequired }}- test "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" || { echo "FIPS mode required but not enabled on this node image" >&2; exit 1; }
+                  {{ end }}{{ if .cisProfile }}- useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                  - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                  - sysctl -p /etc/sysctl.d/90-kubelet.conf
+                  {{ end }}
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: RKE2ConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/preRKE2Commands
+              valueFrom:
+                template: |
+                  {{ if .fipsRequired }}- test "$(cat /proc/sys/crypto/fips_enabled 2>/dev/null)" = "1" || { echo "FIPS mode required but not enabled on this node image" >&2; exit 1; }
+                  {{ end }}{{ if .cisProfile }}- useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U || true
+                  - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
+                  - sysctl -p /etc/sysctl.d/90-kubelet.conf
+                  {{ end }}
     - name: csiAddonConfigMap
       definitions:
         - selector:
@@ -621,6 +650,8 @@ spec:
         value: "${CNI}"
       - name: cisProfile
         value: "${CIS_PROFILE}"
+      - name: fipsRequired
+        value: ${FIPS_REQUIRED}
 ---
 # ClusterResourceSet — CSI plugin DaemonSet + RBAC
 apiVersion: addons.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
## Summary

Adds FIPS enforcement to the shipped ClusterClass, completing the compliance switches announced in `docs/compliance.md`.

- FIPS mode is a boot-time property of the node image (kernel parameter plus the FIPS pattern) and cannot be enabled by cloud-init without breaking the bootstrap, so the provider does not pretend to turn it on. Instead, the new `fipsRequired` topology variable (default `false`) injects a bootstrap guard that fails unless `/proc/sys/crypto/fips_enabled` is `1`: a cluster that must be FIPS can never silently run on a non-FIPS image.
- The compliance guide documents the image build recipe (`zypper -n in -t pattern fips`, `fips=1` in the GRUB command line, `dracut -f`, `cloud-init clean`, volume export as a Harvester image).
- The CIS and FIPS node preparation commands now compose in a single `nodePreparation` patch: two ClusterClass patches both adding `preRKE2Commands` would overwrite each other, so the previous CIS-only patch was restructured (same rendered commands when only `cisProfile` is set).
- The certification suite gains the matching `FIPS_REQUIRED` knob (default `false`).

## Validation

- Negative: the guard was executed inside a standard (non-FIPS) openSUSE Leap guest and fails as intended (`exit 1`, `fips_enabled=0`), which is exactly what would stop a misconfigured bootstrap.
- Image recipe: a FIPS node image was built by following the documented recipe on the standard Leap cloud image and exported through `sourceType: export-from-volume`.
- Positive, combined with CIS: a cluster was created from the shipped ClusterClass with `cisProfile: cis` and `fipsRequired: true` on that image (management cluster bootstrapped with cluster-api-operator, CAPI core v1.12.7, RKE2 providers, released CAPHV v0.9.0, real Harvester 1.8.0). Both nodes bootstrapped through the guard and reached `Ready`, `/proc/sys/crypto/fips_enabled` reads `1` in both guests, the rendered `preRKE2Commands` contain the FIPS guard followed by the CIS prerequisites on both the control plane and the worker templates, and the CIS hardening stays effective (privileged probe pod rejected by PodSecurity restricted).

The run also surfaced a pre-existing requeue gap in the workload node initialization (a machine whose node registers after the last reconcile stays `Provisioned` forever when nothing else triggers events); it is unrelated to this change and fixed separately.
