### PR TITLE
fix: requeue until the workload node is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Workload node initialization requeue**: a machine whose node registered in
+  the workload cluster after the machine's last event-driven reconcile stayed
+  in the `Provisioned` phase forever: the node initialization (providerID,
+  uninitialized taint removal) silently failed and nothing triggered another
+  reconcile. The reconciler now requeues until the node is initialized.
+  Clusters with a MachineHealthCheck were masking the gap (its probes kept
+  generating events); the shipped ClusterClass has none and exposed it.
+
 ### Added
 
 - **FIPS enforcement switch in the ClusterClass**: the new `fipsRequired`

--- a/internal/controller/harvestermachine_controller.go
+++ b/internal/controller/harvestermachine_controller.go
@@ -544,32 +544,39 @@ func (r *HarvesterMachineReconciler) ReconcileNormal(hvScope *Scope) (res reconc
 
 	// Initialize workload cluster node: set providerID and remove uninitialized taint.
 	// This bypasses the cloud-provider bootstrap chicken-and-egg problem.
-	r.initializeWorkloadNode(hvScope)
+	if !r.initializeWorkloadNode(hvScope) {
+		// The node has not registered (or could not be patched) yet. Requeue
+		// explicitly: once the machine events settle, nothing else triggers a
+		// reconcile, and without the providerID on the node the machine would
+		// stay in the Provisioned phase forever.
+		return ctrl.Result{RequeueAfter: requeueDelay}, nil
+	}
 
 	return ctrl.Result{}, nil
 }
 
 // initializeWorkloadNode sets the providerID and removes the cloud-provider
 // uninitialized taint on the workload cluster node corresponding to this machine.
-// Errors are logged as warnings but do not block reconciliation.
+// It reports whether the node is initialized; errors are logged as warnings and
+// surface as a false return so the caller requeues.
 //
 //nolint:funcorder
-func (r *HarvesterMachineReconciler) initializeWorkloadNode(hvScope *Scope) {
+func (r *HarvesterMachineReconciler) initializeWorkloadNode(hvScope *Scope) bool {
 	if hvScope.HarvesterMachine.Spec.ProviderID == "" {
-		return
+		return false
 	}
 
 	workloadConfig, err := getWorkloadClusterConfig(hvScope)
 	if err != nil {
 		// Workload cluster not ready yet, will retry on next reconcile
-		return
+		return false
 	}
 
 	caphvmetrics.NodeInitTotal.Inc()
 
 	initStart := time.Now()
 
-	locutil.InitializeWorkloadNode(
+	initialized := locutil.InitializeWorkloadNode(
 		hvScope.Ctx,
 		*hvScope.Logger,
 		workloadConfig,
@@ -578,6 +585,8 @@ func (r *HarvesterMachineReconciler) initializeWorkloadNode(hvScope *Scope) {
 	)
 
 	caphvmetrics.NodeInitDuration.Observe(time.Since(initStart).Seconds())
+
+	return initialized
 }
 
 func getProviderIDFromWorkloadCluster(hvScope *Scope) (string, error) {

--- a/internal/controller/harvestermachine_controller_test.go
+++ b/internal/controller/harvestermachine_controller_test.go
@@ -2073,8 +2073,9 @@ var _ = Describe("ReconcileNormal", func() {
 		r := &HarvesterMachineReconciler{Client: fakeClient, Scheme: scheme}
 		result, err := r.ReconcileNormal(scope)
 		Expect(err).ToNot(HaveOccurred())
-		// VM was just created, status.Ready should be true at end of ReconcileNormal
-		Expect(result.RequeueAfter).To(BeZero())
+		// VM was just created and its node cannot be initialized yet, so the
+		// reconcile requeues until the node registers and gets its providerID
+		Expect(result.RequeueAfter).To(Equal(requeueDelay))
 
 		// Verify the VM was created on Harvester
 		createdVM, getErr := hvClient.KubevirtV1().VirtualMachines("default").Get(context.TODO(), "test-cp-0", metav1.GetOptions{})
@@ -2285,7 +2286,11 @@ var _ = Describe("ReconcileNormal", func() {
 		r := &HarvesterMachineReconciler{Client: fakeClient, Scheme: scheme}
 		result, err := r.ReconcileNormal(scope)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result.RequeueAfter).To(BeZero())
+		// The workload node is not initialized yet (no reachable workload
+		// cluster here), so the reconcile must requeue until it is: without
+		// this, a node registering after the last event-driven reconcile
+		// leaves the machine Provisioned forever.
+		Expect(result.RequeueAfter).To(Equal(requeueDelay))
 		// ProviderID should be set from VM UID (fallback when kubeconfig unavailable)
 		Expect(scope.HarvesterMachine.Spec.ProviderID).To(Equal("harvester://fake-uid-12345"))
 		Expect(scope.HarvesterMachine.Status.Ready).To(BeTrue())
@@ -2361,7 +2366,7 @@ var _ = Describe("ReconcileNormal", func() {
 		r := &HarvesterMachineReconciler{Client: fakeClient, Scheme: scheme}
 		result, err := r.ReconcileNormal(scope)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result.RequeueAfter).To(BeZero())
+		Expect(result.RequeueAfter).To(Equal(requeueDelay))
 		Expect(scope.HarvesterMachine.Status.Ready).To(BeTrue())
 		Expect(scope.HarvesterMachine.Spec.ProviderID).To(Equal("harvester://already-set"))
 	})
@@ -2620,7 +2625,7 @@ var _ = Describe("ReconcileNormal", func() {
 		r := &HarvesterMachineReconciler{Client: fakeClient, Scheme: scheme}
 		result, err := r.ReconcileNormal(scope)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result.RequeueAfter).To(BeZero())
+		Expect(result.RequeueAfter).To(Equal(requeueDelay))
 		// Should have allocated an IP
 		Expect(scope.HarvesterMachine.Status.AllocatedIPAddress).ToNot(BeEmpty())
 		// EffectiveNetworkConfig should be populated
@@ -2702,7 +2707,7 @@ var _ = Describe("ReconcileNormal", func() {
 		r := &HarvesterMachineReconciler{Client: fakeClient, Scheme: scheme}
 		result, err := r.ReconcileNormal(scope)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result.RequeueAfter).To(BeZero())
+		Expect(result.RequeueAfter).To(Equal(requeueDelay))
 		// EffectiveNetworkConfig should use machine-level config
 		Expect(scope.EffectiveNetworkConfig).ToNot(BeNil())
 		Expect(scope.EffectiveNetworkConfig.Address).To(Equal("10.0.0.100"))

--- a/util/node_init.go
+++ b/util/node_init.go
@@ -43,35 +43,35 @@ const (
 //
 // This is a best-effort operation: all errors are logged as warnings
 // and do not propagate, so it never blocks the reconcile loop.
-func InitializeWorkloadNode(ctx context.Context, logger logr.Logger, workloadConfig *rest.Config, nodeName, providerID string) {
+func InitializeWorkloadNode(ctx context.Context, logger logr.Logger, workloadConfig *rest.Config, nodeName, providerID string) bool {
 	if providerID == "" {
-		return
+		return false
 	}
 
 	clientset, err := kubernetes.NewForConfig(workloadConfig)
 	if err != nil {
 		logger.Info("Warning: failed to create workload client for node init", "error", err)
 
-		return
+		return false
 	}
 
 	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// Node not yet registered in workload cluster, will retry next reconcile
-			return
+			// Node not yet registered in workload cluster: report it so the caller requeues
+			return false
 		}
 
 		logger.Info("Warning: failed to get workload node for init", "error", err, "node", nodeName)
 
-		return
+		return false
 	}
 
 	needsProviderID := node.Spec.ProviderID == ""
 	needsTaintRemoval := hasUninitializedTaint(node)
 
 	if !needsProviderID && !needsTaintRemoval {
-		return
+		return true
 	}
 
 	if needsProviderID {
@@ -82,7 +82,7 @@ func InitializeWorkloadNode(ctx context.Context, logger logr.Logger, workloadCon
 			logger.Info("Warning: failed to set providerID on workload node",
 				"error", err, "node", nodeName, "providerID", providerID)
 
-			return
+			return false
 		}
 
 		logger.Info("Set providerID on workload node", "node", nodeName, "providerID", providerID)
@@ -94,7 +94,7 @@ func InitializeWorkloadNode(ctx context.Context, logger logr.Logger, workloadCon
 		if err != nil {
 			logger.Info("Warning: failed to re-fetch node after providerID patch", "error", err)
 
-			return
+			return false
 		}
 
 		newTaints := removeTaint(node.Spec.Taints)
@@ -103,7 +103,7 @@ func InitializeWorkloadNode(ctx context.Context, logger logr.Logger, workloadCon
 			if err != nil {
 				logger.Info("Warning: failed to marshal taints", "error", err, "node", nodeName)
 
-				return
+				return false
 			}
 
 			patch := fmt.Sprintf(`{"spec":{"taints":%s}}`, taintsJSON)
@@ -113,12 +113,14 @@ func InitializeWorkloadNode(ctx context.Context, logger logr.Logger, workloadCon
 				logger.Info("Warning: failed to remove uninitialized taint",
 					"error", err, "node", nodeName)
 
-				return
+				return false
 			}
 
 			logger.Info("Removed cloud-provider uninitialized taint", "node", nodeName)
 		}
 	}
+
+	return true
 }
 
 // hasUninitializedTaint returns true if the node has the cloud-provider uninitialized taint.

--- a/util/node_init_test.go
+++ b/util/node_init_test.go
@@ -171,8 +171,7 @@ func fakeNodeServer(node *v1.Node) (*httptest.Server, *rest.Config) {
 var _ = Describe("InitializeWorkloadNode with fake API server", func() {
 	It("should return immediately when providerID is empty", func() {
 		logger := logr.Discard()
-		InitializeWorkloadNode(context.Background(), logger, &rest.Config{Host: "http://unused"}, "test-node", "")
-		// No panic, no error - function returns immediately
+		Expect(InitializeWorkloadNode(context.Background(), logger, &rest.Config{Host: "http://unused"}, "test-node", "")).To(BeFalse())
 	})
 
 	It("should set providerID and remove taint on a node", func() {
@@ -193,7 +192,7 @@ var _ = Describe("InitializeWorkloadNode with fake API server", func() {
 		defer server.Close()
 
 		logger := logr.Discard()
-		InitializeWorkloadNode(context.Background(), logger, config, "test-node", "harvester://test-provider-id")
+		Expect(InitializeWorkloadNode(context.Background(), logger, config, "test-node", "harvester://test-provider-id")).To(BeTrue())
 
 		// Verify by fetching the node again through the fake server
 		// The function should have set providerID and removed the uninitialized taint
@@ -216,8 +215,8 @@ var _ = Describe("InitializeWorkloadNode with fake API server", func() {
 		defer server.Close()
 
 		logger := logr.Discard()
-		// No taint, providerID already set - should be a no-op
-		InitializeWorkloadNode(context.Background(), logger, config, "already-initialized", "harvester://new-id")
+		// No taint, providerID already set - should be a no-op reported as initialized
+		Expect(InitializeWorkloadNode(context.Background(), logger, config, "already-initialized", "harvester://new-id")).To(BeTrue())
 	})
 
 	It("should handle node not found (not registered yet)", func() {
@@ -232,8 +231,9 @@ var _ = Describe("InitializeWorkloadNode with fake API server", func() {
 		defer server.Close()
 
 		logger := logr.Discard()
-		// Request for a different node name - should get 404 and return silently
-		InitializeWorkloadNode(context.Background(), logger, config, "non-existent-node", "harvester://some-id")
+		// Request for a different node name: not initialized, the caller must requeue
+		// (a machine whose node registers later would otherwise stay Provisioned forever)
+		Expect(InitializeWorkloadNode(context.Background(), logger, config, "non-existent-node", "harvester://some-id")).To(BeFalse())
 	})
 
 	It("should only set providerID when there is no taint", func() {
@@ -254,7 +254,7 @@ var _ = Describe("InitializeWorkloadNode with fake API server", func() {
 		defer server.Close()
 
 		logger := logr.Discard()
-		InitializeWorkloadNode(context.Background(), logger, config, "needs-pid-only", "harvester://pid-only")
+		Expect(InitializeWorkloadNode(context.Background(), logger, config, "needs-pid-only", "harvester://pid-only")).To(BeTrue())
 	})
 
 	It("should only remove taint when providerID is already set", func() {


### PR DESCRIPTION
## Summary

Fixes a requeue gap in the workload node initialization that leaves machines in the `Provisioned` phase forever.

When a machine's node registers in the workload cluster after the machine's last event-driven reconcile, `initializeWorkloadNode` silently fails (node not found) and the reconcile returns without requeue. Once the machine events settle, nothing triggers another reconcile: the providerID is never set on the node, CAPI never matches the node to the machine, and the machine stays `Provisioned` while its node is `Ready`.

Clusters with a MachineHealthCheck mask the gap because its periodic probes keep generating machine events that re-trigger the infra reconcile; the shipped ClusterClass has no MHC and exposed the bug.

Fix: `util.InitializeWorkloadNode` now reports whether the node is initialized (already initialized, or successfully patched), any failure or missing node surfaces as `false`, and the reconciler requeues until it succeeds.

## Validation

- Observed live on a real cluster created from the shipped ClusterClass (no MHC): worker node `Ready` for 55 minutes with an empty `spec.providerID`, machine stuck `Provisioned`, controller logs showing the reconciles stopped before the node registered. Touching an annotation on the HarvesterMachine (forcing one reconcile) immediately initialized the node and moved the machine to `Running`, confirming the missing-requeue diagnosis.
- Unit tests: the node initialization tests now assert the returned state (initialized on success and on already-initialized nodes, not initialized when the node is absent), and the reconcile tests assert the requeue on the not-yet-initialized path.
