### PR TITLE
fix: attach cluster template flavors to the release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,12 @@ jobs:
         if [ -n "$STALE_ID" ]; then
           gh api -X DELETE repos/${{ github.repository }}/releases/$STALE_ID
         fi
-        gh release create ${{ github.ref_name }} --draft --generate-notes out/metadata.yaml out/infrastructure-components.yaml
+        gh release create ${{ github.ref_name }} --draft --generate-notes \
+          out/metadata.yaml out/infrastructure-components.yaml \
+          out/cluster-template.yaml out/cluster-template-dhcp.yaml \
+          out/cluster-template-generateCPI.yaml out/cluster-template-kubeadm.yaml \
+          out/cluster-template-talos.yaml out/cluster-template-stig.yaml \
+          out/clusterclass-harvester-rke2.yaml
         # The list API lags slightly behind the creation: retry the id lookup.
         DRAFT_ID=""
         for _ in $(seq 1 10); do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cluster template flavors shipped as release assets**: the release workflow
+  only uploaded `infrastructure-components.yaml` and `metadata.yaml`, so the
+  cluster template flavors (including the new `stig` one) and the ClusterClass
+  were never downloadable and `clusterctl generate cluster --flavor ...` could
+  not work against a release. All `out/` artifacts are now attached to the
+  release draft. Releases are immutable on this repository, so the missing
+  assets could not be added to v0.10.0 retroactively; use this release instead.
+
 ## [v0.10.0] - 2026-07-28
 
 ### Fixed


### PR DESCRIPTION
The release workflow only uploaded `infrastructure-components.yaml` and `metadata.yaml`: the cluster template flavors (including the new `stig` one) and the ClusterClass were never downloadable, so `clusterctl generate cluster --flavor ...` could not work against a release. All `out/` artifacts are now attached to the release draft.

Releases are immutable on this repository, so the missing assets could not be added to v0.10.0 retroactively; a patch release will carry them.