### PR TITLE
docs: full refresh to the v0.10.1 state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to CAPHV (Cluster API Provider Harve
 
 ### Prerequisites
 
-- Go 1.24+ (see `go.mod` for exact version)
+- Go 1.26+ (see `go.mod` for exact version)
 - `kubectl` configured with access to a management cluster
 - Access to a Harvester HCI cluster (v1.7+)
 - [cert-manager](https://cert-manager.io/) installed on the management cluster (for webhooks)
@@ -73,7 +73,7 @@ export CAPHV_HARVESTER_SSH="rancher@<your-harvester-ip>"
 
 ## Pull Request Process
 
-1. Fork the repository and create a feature branch from `harvester-v1.7.1`
+1. Fork the repository and create a feature branch from `main`
 2. Make your changes, ensuring all tests pass
 3. Write clear commit messages describing **why** the change was made
 4. Open a PR with a description of the change and any relevant issue references
@@ -97,8 +97,8 @@ golangci-lint run ./...
 Key conventions:
 - Follow standard Go project layout
 - Use `controller-runtime` patterns for reconcilers
-- Admission webhooks implement `admission.CustomValidator` (not the deprecated `webhook.Validator`)
-- API types live in `api/v1alpha1/`
+- Admission webhooks implement the typed `admission.Validator[T]` (not the deprecated `webhook.Validator`)
+- API types live in `api/v1beta1/` (hub and stored version; `api/v1alpha1/` is deprecated and served through conversion)
 - Controller logic lives in `internal/controller/`
 - Utility functions live in `util/`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ production capabilities:
 | CLI generator | None | `caphv-generate` script (~30-line clusters) |
 | Fleet/CAAPF addons | Not supported | CSI/CNI via Fleet GitOps with per-cluster CNI tuning |
 | Helm chart | None | Full chart with webhook + ClusterClass support |
+| Multi-network clusters | Single network | Network-aware pool selection + per machine type `vmNetworkConfig` (separate control-plane/worker networks) |
+| Boot security | BIOS only | UEFI Secure Boot + vTPM per machine type |
+| Failure domains | Not published | Discovered from Harvester hosts/zones, control plane spread |
+| Hardening | None | `cisProfile` and `fipsRequired` ClusterClass switches, STIG flavor, compliance guide |
 
 ## Prerequisites
 
@@ -89,9 +93,9 @@ metadata:
 spec:
   name: harvester
   type: infrastructure
-  version: v0.5.2
+  version: v0.10.1
   fetchConfig:
-    url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.5.2/infrastructure-components.yaml
+    url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml
   configSecret:
     name: caphv-variables
 ```
@@ -109,13 +113,13 @@ See [docs/operations.md](docs/operations.md) for full CAPIProvider deployment, u
 helm install caphv chart/caphv/ \
   -n caphv-system --create-namespace \
   --set image.repository=ghcr.io/rancher-sandbox/cluster-api-provider-harvester \
-  --set image.tag=v0.5.2
+  --set image.tag=v0.10.1
 
 # With webhooks (requires cert-manager)
 helm install caphv chart/caphv/ \
   -n caphv-system --create-namespace \
   --set image.repository=ghcr.io/rancher-sandbox/cluster-api-provider-harvester \
-  --set image.tag=v0.5.2 \
+  --set image.tag=v0.10.1 \
   --set webhooks.enabled=true \
   --set webhooks.certManager.enabled=true
 ```
@@ -124,10 +128,10 @@ helm install caphv chart/caphv/ \
 
 ```bash
 # Build and push the image
-make docker-build docker-push IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.5.2
+make docker-build docker-push IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.10.1
 
 # Deploy
-make deploy IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.5.2
+make deploy IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.10.1
 ```
 
 ### Option 4: Manual (standalone manifests)
@@ -288,7 +292,7 @@ spec:
     services:
       cidrBlocks: [10.53.0.0/16]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: my-cluster-cp
   infrastructureRef:
@@ -382,7 +386,9 @@ Harvester HCI (target)
 | `spec.loadBalancerConfig.ipamType` | string | Yes | `pool` or `dhcp` |
 | `spec.vmNetworkConfig.gateway` | string | Yes* | Gateway IP (*required for pool IPAM) |
 | `spec.vmNetworkConfig.subnetMask` | string | Yes* | Subnet mask (e.g. "255.255.0.0") |
-| `spec.vmNetworkConfig.ipPoolRef` | string | No | Reference to Harvester IPPool |
+| `spec.vmNetworkConfig.ipPoolRef` | string | No | Reference to a Harvester IPPool |
+| `spec.vmNetworkConfig.ipPoolRefs` | []string | No | Multiple pools, ordered fallback + network-aware selection (a pool whose `selector.network` matches one of the machine's networks) |
+| `spec.vmNetworkConfig.ipPool` | object | No | Inline IPPool to create in Harvester (cluster level only) |
 
 > **DHCP mode**: If `vmNetworkConfig` is omitted and no machine-level `networkConfig` is set, all VM NICs will use DHCP automatically. No IPPool or static IP configuration is needed.
 
@@ -401,6 +407,12 @@ Harvester HCI (target)
 | `spec.volumes[].storageClass` | string | For SC | Storage class for blank disk |
 | `spec.volumes[].volumeSize` | string | Yes | Disk size (e.g. "40Gi") |
 | `spec.volumes[].bootOrder` | int | No | Boot priority (1 = first) |
+| `spec.networkConfig` | object | No | Static IP configuration for this machine (address, gateway, DNS) |
+| `spec.vmNetworkConfig` | object | No | Machine-level pool-based network config overriding the cluster-level one (pools, gateway, subnet mask, DNS); mutually exclusive with `networkConfig` |
+| `spec.firmware` | object | No | `efi` and `secureBoot` (Secure Boot requires EFI) |
+| `spec.tpm` | object | No | `enabled` and `persistent` emulated TPM device |
+| `spec.nodeAffinity` / `spec.workloadAffinity` | object | No | VM scheduling constraints on Harvester hosts / other workloads |
+| `spec.failureDomain` | string | No | Failure domain to pin the VM to (normally set by CAPI from the published domains) |
 
 ## Monitoring
 
@@ -414,9 +426,13 @@ See [docs/operations.md](docs/operations.md) for the full metrics list and alert
 
 ## Documentation
 
-- [Operations Guide](docs/operations.md) - installation via CAPIProvider, cluster lifecycle, monitoring, backup/DR
+- [Operations Guide](docs/operations.md) - installation via CAPIProvider, cluster lifecycle, multi-pool and per machine type networking, encrypted storage, failure domains, Secure Boot/vTPM, monitoring, backup/DR
+- [Compliance Guide](docs/compliance.md) - BSI APP.4.4, CIS, DISA STIG, FIPS and ANSSI mapping per layer, with the provider switches to use
+- [Compatibility Matrix](docs/compatibility.md) - certified CAPHV / Rancher / Turtles / CAPI pairings
 - [Fleet Addons Guide](docs/fleet-addons.md) - Fleet/CAAPF addon management for CSI and CNI
 - [Troubleshooting](docs/troubleshooting.md) - IPPool, cloud-init, DHCP, Turtles/Rancher, VM creation, etcd
+- [Release Process](docs/release-process.md) - immutable release flow, assets, certification bump checklist
+- Migration guides: [v0.2 to v0.3](docs/migration-v0.2-to-v0.3.md), [v0.4 to v0.5](docs/migration-v0.4-to-v0.5.md)
 
 ## E2E Tests
 
@@ -437,7 +453,7 @@ Integration tests run against a live Harvester + CAPI cluster:
 make build
 
 # Build container image
-make docker-build IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.5.2
+make docker-build IMG=ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.10.1
 
 # Run unit tests
 make test
@@ -458,7 +474,7 @@ identity.
 Verify the container image:
 
 ```bash
-cosign verify ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.5.2 \
+cosign verify ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.10.1 \
   --certificate-identity-regexp "^https://github.com/rancher-sandbox/cluster-api-provider-harvester" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -467,7 +483,7 @@ Verify the SLSA build provenance with the GitHub CLI:
 
 ```bash
 gh attestation verify \
-  oci://ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.5.2 \
+  oci://ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.10.1 \
   --owner rancher-sandbox
 ```
 
@@ -487,6 +503,13 @@ CAPHV ↔ Rancher/Turtles/CAPI pairing matrix lives in
 
 | Version | Date | Key changes |
 |---------|------|-------------|
+| v0.10.1 | 2026-07-28 | Release assets now include the cluster template flavors and the ClusterClass (`clusterctl generate cluster --flavor ...` works against releases) |
+| v0.10.0 | 2026-07-28 | `cisProfile` and `fipsRequired` ClusterClass hardening switches, STIG-hardened template flavor, compliance guide; fix: requeue until the workload node is initialized |
+| v0.9.0 | 2026-07-28 | Failure domains: discovery from Harvester hosts/zones, publication for the CAPI contract, placement via node affinity (#237) |
+| v0.8.0 | 2026-07-28 | UEFI Secure Boot and vTPM options per machine type (#238) |
+| v0.7.0 | 2026-07-27 | Per machine type network configuration: machine-level `vmNetworkConfig` (#234) |
+| v0.6.1 | 2026-07-27 | Network-aware IP pool selection for `ipPoolRefs`; webhook accepts list-only pool sources |
+| v0.6.0 | 2026-07-20 | Build ecosystem on CAPI v1.13.4 / controller-runtime v0.23.3; typed admission validators |
 | v0.5.2 | 2026-07-20 | Image StorageClass resolved from the image status (fixes PVC Pending on freshly created images, #211); immutable-releases-compatible release flow (#218); kubevirt.io/api 1.8.4, harvester-load-balancer 1.8.1, Go 1.26, security bumps |
 | v0.5.1 | 2026-07-17 | cert-manager CA injection restored on the clustertemplates CRD (required for installs through a Turtles CAPIProvider); RBAC for provisioning.cattle.io; Turtles integration suite (CreateUsingGitOpsSpec) on a self-hosted runner |
 | v0.5.0 | 2026-07-06 | API graduation v1alpha1 -> v1beta1 (hub with conversion webhooks, fuzz-tested round-trip); deprecated failure fields dropped |

--- a/blogpost.md
+++ b/blogpost.md
@@ -2,6 +2,12 @@
 
 *How I forked an inactive CAPI infrastructure provider for Harvester and brought it to production-grade quality -- validated by a formal SUSE engineering review.*
 
+> **Update, July 2026**: this article describes the state as of v0.2.8 (March 2026).
+> The project has since graduated its API to `v1beta1`, published the CAPI v1beta2
+> contract, and reached v0.10.1 with multi-network clusters, Secure Boot/vTPM,
+> failure domains and CIS/STIG/FIPS hardening options; see the README and CHANGELOG
+> for the current state.
+
 ---
 
 ## The Problem
@@ -344,7 +350,7 @@ The project underwent a formal code review by the SUSE CAPI engineering team, co
 
 - A management Kubernetes cluster (RKE2 recommended)
 - CAPI Core, RKE2 Bootstrap, and RKE2 ControlPlane providers installed (e.g., via Rancher Turtles)
-- A Harvester HCI cluster (v1.7.x)
+- A Harvester HCI cluster (v1.7.x/v1.8.x)
 - A VM image uploaded to Harvester (e.g., SLES 15 SP7)
 - An SSH key pair created on Harvester
 - cert-manager (for webhook TLS -- or use Turtles' no-cert-manager feature)
@@ -377,8 +383,8 @@ Use the ClusterClass approach (see the example above) or the CLI generator. In a
 ## What's Next
 
 - **CAPI IPAM Provider** -- decouple the IP allocation logic into a standalone [IPAM Provider](https://cluster-api.sigs.k8s.io/developer/providers/contracts/ipam) for cleaner separation of concerns and a standard CAPI-compliant API
-- **CAPI v1beta2 migration** -- adopt `status.initialization.provisioned` and new condition types when the v1beta2 contract stabilizes
-- **Harvester v1.8.x compatibility** -- validate against upcoming API changes
+- **CAPI v1beta2 migration** -- delivered since: v0.4.0 publishes the v1beta2 contract (`status.initialization.provisioned`, `Paused` condition) and v0.5.0 graduates the API to `v1beta1`
+- **Harvester v1.8.x compatibility** -- delivered since: validated continuously against Harvester 1.8 by the certification suites
 - **CAAPF evolution** -- adapt Fleet addon integration as the CAAPF API evolves ([RFD 0051](https://github.com/SUSE/rancher-architecture/pull/51))
 
 The project is open source: [github.com/rancher-sandbox/cluster-api-provider-harvester](https://github.com/rancher-sandbox/cluster-api-provider-harvester)

--- a/caphv-quickstart.md
+++ b/caphv-quickstart.md
@@ -106,7 +106,7 @@ EOF
 > **Point critique** : KubeVirt utilise un bridge binding qui **intercepte le
 > trafic DHCP externe**. Les VMs ne peuvent PAS obtenir une IP via DHCP depuis
 > le reseau physique. Il faut obligatoirement configurer une **IP statique**
-> soit via `vmNetworkConfig` (rc7+, recommande), soit via `networkConfig` manuel.
+> soit via `vmNetworkConfig` (recommande), soit via `networkConfig` manuel.
 
 ---
 
@@ -115,45 +115,27 @@ EOF
 ### Providers deja installes (via Rancher Turtles)
 
 Sur notre Rancher Manager, Turtles a deja installe :
-- CAPI Core v1.10.6
+- CAPI Core v1.12.x
 - RKE2 Bootstrap v0.21.1
 - RKE2 Control Plane v0.21.1
 
 ### Deployer CAPHV
 
 ```bash
-# Build de l'image (depuis node1)
-cd /tmp/caphv
-podman build --build-arg TARGETARCH=amd64 . \
-  -t ghcr.io/rancher-sandbox/cluster-api-provider-harvester:dev
-
-# Transferer l'image sur le management cluster (si pas de registry)
-podman save ghcr.io/rancher-sandbox/cluster-api-provider-harvester:dev \
-  | ssh <user>@<management-node> 'sudo /var/lib/rancher/rke2/bin/ctr \
-    --address /run/k3s/containerd/containerd.sock \
-    --namespace k8s.io images import -'
-
-# Deployer les CRDs et le controller
-# (depuis le management cluster)
-kubectl apply -f config/crd/bases/
-kubectl label crd harvesterclusters.infrastructure.cluster.x-k8s.io \
-  cluster.x-k8s.io/v1beta1=v1alpha1
-kubectl label crd harvestermachinetemplates.infrastructure.cluster.x-k8s.io \
-  cluster.x-k8s.io/v1beta1=v1alpha1
-kubectl label crd harvestermachines.infrastructure.cluster.x-k8s.io \
-  cluster.x-k8s.io/v1beta1=v1alpha1
-kubectl label crd harvesterclustertemplates.infrastructure.cluster.x-k8s.io \
-  cluster.x-k8s.io/v1beta1=v1alpha1
-
-# Deployer le controller manager
-kubectl apply -f config/default/
+# Installer la derniere release (les CRDs portent deja les labels de contrat
+# v1beta1 + v1beta2 ; aucune manipulation manuelle n'est necessaire)
+kubectl apply -f https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml
 ```
+
+Alternatives : via un `CAPIProvider` Turtles ou `clusterctl init --infrastructure
+harvester:v0.10.1` (voir `docs/operations.md`). Le build d'image local n'est utile
+que pour le developpement (`make docker-build`).
 
 ---
 
 ## Creer un cluster RKE2
 
-### Methode recommandee : avec allocation IP automatique (v0.2.0-rc7+, rc10 recommande)
+### Methode recommandee : avec allocation IP automatique
 
 Cette methode utilise `vmNetworkConfig` sur le HarvesterCluster pour allouer
 automatiquement une IP unique a chaque VM depuis un IPPool Harvester.
@@ -189,15 +171,15 @@ metadata:
     csi: external
 spec:
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: capi-test-cp
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: HarvesterCluster
     name: capi-test-hv
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HarvesterCluster
 metadata:
   name: capi-test-hv
@@ -227,7 +209,7 @@ spec:
     dnsSearch:
       - "home.lo"
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: capi-test-cp
@@ -244,12 +226,12 @@ spec:
     cni: calico
     cloudProviderName: external
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: HarvesterMachineTemplate
     name: capi-test-machine
     namespace: capi-test
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HarvesterMachineTemplate
 metadata:
   name: capi-test-machine
@@ -292,7 +274,7 @@ spec:
 ```
 
 > **Limite** : avec cette methode, tous les noeuds recoivent la meme IP.
-> Utiliser `vmNetworkConfig` (rc7+) pour le multi-noeud.
+> Utiliser `vmNetworkConfig` pour le multi-noeud.
 
 ### Appliquer
 
@@ -324,14 +306,14 @@ sudo systemctl status rke2-server
 sudo /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes
 ```
 
-### Initialisation des noeuds (automatique depuis rc10)
+### Initialisation des noeuds (automatique)
 
 Le cloud-provider-harvester a besoin du reseau pod (calico) pour atteindre
 l'API Harvester et initialiser les noeuds (supprimer le taint `uninitialized`
 et definir le `providerID`). Mais calico est bloque par le taint
-`uninitialized` — c'est un probleme oeuf/poule.
+`uninitialized` - c'est un probleme oeuf/poule.
 
-**Depuis rc10** : CAPHV resout ce probleme automatiquement. Le controller
+CAPHV resout ce probleme automatiquement. Le controller
 set le `providerID` et retire le taint `uninitialized` directement sur le
 noeud du workload cluster depuis le management cluster, sans passer par le
 cloud-provider. Cela debloque calico, qui debloque le cloud-provider pour
@@ -390,7 +372,7 @@ Les machines sont supprimees progressivement. Les IPs sont liberees dans le pool
 
 ---
 
-## Resultat teste (v0.2.0-rc11, 2026-03-06)
+## Resultat teste (historique : v0.2.0, 2026-03-06 ; le cycle actuel est valide en continu par les suites de test/certification)
 
 Cluster `capi-test` avec 3 control plane nodes :
 
@@ -403,22 +385,22 @@ Cluster `capi-test` avec 3 control plane nodes :
 IPPool `capi-vm-pool` : 3/10 allouees, 7 disponibles.
 Cluster importe dans Rancher : `c-kzz9c`, statut Active.
 
-### Test de remediation automatique (rc10)
+### Test de remediation automatique
 
-Scenario : suppression d'une VM control-plane → remplacement sans intervention manuelle.
+Scenario : suppression d'une VM control-plane -> remplacement sans intervention manuelle.
 
 Timeline :
 - T+0 : VM `capi-test-machine-b9sm6` (172.16.3.46) supprimee sur Harvester
 - T+0s : Noeud passe `NotReady`, MHC detecte le noeud unhealthy
 - T+5min : MHC depasse le seuil (5min NotReady), marque la Machine pour suppression
 - T+5min : ReconcileDelete : IP liberee, nettoyage etcd execute
-  (membre deja retire par RKE2ControlPlane → "nothing to remove")
+  (membre deja retire par RKE2ControlPlane -> "nothing to remove")
 - T+5min : Secret cloud-init et VM supprimes, nouvelle Machine cree par RKE2ControlPlane
 - T+6min : Nouvelle VM `capi-test-machine-2jjjk` Running sur Harvester (IP 172.16.3.47)
 - T+8min : Nouveau noeud rejoint le cluster, providerID et taint geres automatiquement
 - T+9min : 3 noeuds `Ready`, cluster pleinement operationnel
 
-Aucune intervention manuelle requise — ni pour l'initialisation, ni pour le remplacement.
+Aucune intervention manuelle requise - ni pour l'initialisation, ni pour le remplacement.
 
 ---
 
@@ -452,7 +434,7 @@ Aucune intervention manuelle requise — ni pour l'initialisation, ni pour le re
 
 | Bug | Impact | Correction |
 |-----|--------|------------|
-| Topologie CPU : `sockets * cores * threads` applique 3 fois | VMs recevaient CPU^3 vCPUs (ex: 2 CPU → 8 vCPUs) | `sockets=1, threads=1, cores=N` pour N vCPUs demandes |
+| Topologie CPU : `sockets * cores * threads` applique 3 fois | VMs recevaient CPU^3 vCPUs (ex: 2 CPU -> 8 vCPUs) | `sockets=1, threads=1, cores=N` pour N vCPUs demandes |
 
 ### Amelioration rc9 : nettoyage etcd automatique
 
@@ -476,16 +458,16 @@ Aucune intervention manuelle requise — ni pour l'initialisation, ni pour le re
 
 | Fix | Detail |
 |-----|--------|
-| **PVCs orphelins a la suppression VM** | L'ancien flux supprimait les PVCs pendant que la VM terminait → webhook Harvester bloquait → au retry, VM disparue → PVCs jamais nettoyes. Nouveau flux : supprimer VM → requeue 10s → lister et supprimer PVCs par prefixe une fois la VM partie |
+| **PVCs orphelins a la suppression VM** | L'ancien flux supprimait les PVCs pendant que la VM terminait -> webhook Harvester bloquait -> au retry, VM disparue -> PVCs jamais nettoyes. Nouveau flux : supprimer VM -> requeue 10s -> lister et supprimer PVCs par prefixe une fois la VM partie |
 | **`memory.guest` manquant dans le domain spec** | Apres upgrade Harvester/KubeVirt, `memory.guest` ou `resources.limits.memory` est obligatoire. Les VMs creees avec seulement `resources.requests.memory` ne demarraient plus et n'affichaient pas la memoire dans l'UI. Corrige : `memory.guest` est maintenant defini sur chaque VM creee |
-| **Procedure de redemarrage post-upgrade Harvester** | Apres upgrade, les VMs existantes necessitent un patch manuel : `kubectl patch vm <name> --type=json -p '[{"op":"add","path":"/spec/template/spec/domain/memory","value":{"guest":"<MEM>"}}]'`. De plus, `spec.running` est deprecie → utiliser `spec.runStrategy: Always` |
+| **Procedure de redemarrage post-upgrade Harvester** | Apres upgrade, les VMs existantes necessitent un patch manuel : `kubectl patch vm <name> --type=json -p '[{"op":"add","path":"/spec/template/spec/domain/memory","value":{"guest":"<MEM>"}}]'`. De plus, `spec.running` est deprecie -> utiliser `spec.runStrategy: Always` |
 
 ### Limites vs Terraform
 
 | | CAPI/CAPHV | Terraform |
 |---|---|---|
 | **Reconciliation continue** | Oui (controller loop) | Non (run manuel) |
-| **Multi-disk** | Non (1 disk) | Oui |
+| **Multi-disk** | Oui (multi-disk) | Oui |
 | **DHCP** | Non (bridge KubeVirt) | Oui (cloud-init gere par Harvester) |
 | **Maturite** | Alpha | Stable |
 | **Scaling** | Declaratif (replicas) avec IP pool auto | Manuel |
@@ -527,7 +509,7 @@ Depuis rc10, l'initialisation des noeuds est entierement automatique (plus
 besoin d'intervention manuelle sur le premier noeud), l'import Rancher est
 confirme automatique via Turtles, et des webhooks de validation sont
 disponibles. Le cycle complet fonctionne sans intervention :
-creation → scaling → remediation → remplacement en ~9 minutes.
+creation -> scaling -> remediation -> remplacement en ~9 minutes.
 
 Depuis rc11, les PVCs orphelins sont correctement nettoyes a la suppression
 de VMs, et la compatibilite avec les nouvelles versions de KubeVirt
@@ -536,6 +518,8 @@ de VMs, et la compatibilite avec les nouvelles versions de KubeVirt
 La seule limitation operationnelle restante est le besoin d'une image VM
 avec `iptables` pour les pods utilisant portmap CNI.
 
-Pour un usage production sur Harvester aujourd'hui, Terraform ou le
-provisioning natif Rancher restent plus matures, mais CAPHV offre une
-approche GitOps superieure pour les environnements multi-clusters.
+CAPHV est aujourd'hui utilisable en production : API v1beta1 stable, suites de
+certification continues contre un Harvester reel, deploiements industriels
+multi-VLAN, et options de durcissement (CIS, STIG, FIPS, Secure Boot/vTPM,
+failure domains). Son approche GitOps en fait l'outil de choix pour les
+environnements multi-clusters.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,6 +6,7 @@ which CAPHV release works with what, and how each pairing is validated.
 
 | CAPHV | Provider API | CAPI contract published | CAPI core | Rancher / Turtles | Validation |
 |-------|--------------|-------------------------|-----------|-------------------|------------|
+| v0.6.x-v0.10.x | `v1beta1` (`v1alpha1` served, deprecated) | v1beta1 + v1beta2 | v1.12.x (built against v1.13.4) | Rancher 2.14.x / Turtles 0.26.x | Turtles integration suite (`CreateUsingGitOpsSpec`) twice a week on a real Harvester (self-hosted runner), functional RC runs for every feature release, user production deployment with three node categories on separate VLANs ([#234](https://github.com/rancher-sandbox/cluster-api-provider-harvester/issues/234)) |
 | v0.5.x | `v1beta1` (`v1alpha1` served, deprecated) | v1beta1 + v1beta2 | v1.12.x | Rancher 2.14.x / Turtles 0.26.x | nightly version-pairing (CAPI v1.12.7), Rancher-stack suite (2.14.1, Turtles 109.0.1+up0.26.1, core v1.12.2), Turtles integration suite on real Harvester |
 | v0.4.x | `v1alpha1` | v1beta1 + v1beta2 | v1.12.x | Rancher 2.14.x / Turtles 0.26.x | nightly version-pairing, real-Harvester runs |
 | v0.3.x | `v1alpha1` | v1beta1 | v1.12.x | Rancher 2.13–2.14 / Turtles 0.25–0.26 | real-Harvester runs (homelab) |

--- a/docs/fleet-addons.md
+++ b/docs/fleet-addons.md
@@ -58,10 +58,12 @@ This creates a `CAPIProvider` resource that Turtles installs in `caapf-system`. 
 
 ```bash
 kubectl get capiprovider -A
-# fleet   addon   fleet   v0.12.0   Ready
+# fleet   addon   fleet   v0.13.x   Ready
 ```
 
-**Version compatibility**: CAAPF v0.12.0 works with CAPI v1.10.x (v1beta1). CAAPF v0.13+ requires CAPI v1.11+ (v1beta2).
+**Version compatibility**: with the current ecosystem (CAPI core v1.12.x, v1beta2
+contract) use CAAPF v0.13+. The older CAAPF v0.12.0 only works with CAPI v1.10.x
+(v1beta1) and cannot be used with the stack CAPHV v0.3.0+ targets.
 
 ### Fleet Addons Repository
 
@@ -128,7 +130,7 @@ These are stored as cluster annotations (`caphv.io/cni-*`) for reference and fut
 4. Labels must be added to the Fleet Cluster for bundle targeting (e.g., `cni: calico`)
 5. The `GitRepo` bundle deploys matching CNI config to the workload cluster
 
-**Important**: CAAPF v0.12.0 does not automatically propagate CAPI cluster labels to Fleet clusters. After cluster creation, you may need to:
+**Important**: depending on the CAAPF version, CAPI cluster labels may not be propagated automatically to Fleet clusters (observed with v0.12.0). After cluster creation, you may need to:
 - Set `fleetWorkspaceName: fleet-default` on the management cluster
 - Add labels to the Fleet cluster for bundle matching
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,9 +36,9 @@ metadata:
 spec:
   name: harvester
   type: infrastructure
-  version: v0.3.0
+  version: v0.10.1
   fetchConfig:
-    url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.3.0/infrastructure-components.yaml
+    url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml
   configSecret:
     name: caphv-variables
 ```
@@ -96,7 +96,7 @@ metadata:
 spec:
   name: harvester
   type: infrastructure
-  version: v0.3.0
+  version: v0.10.1
   enableAutomaticUpdate: true
   fetchConfig:
     url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/latest/download/infrastructure-components.yaml
@@ -114,9 +114,9 @@ Key differences from manual deployment:
 # 1. Update the CAPIProvider version and URL
 kubectl patch capiprovider harvester -n caphv-system --type merge -p '{
   "spec": {
-    "version": "v0.3.0",
+    "version": "v0.10.1",
     "fetchConfig": {
-      "url": "https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.3.0/infrastructure-components.yaml"
+      "url": "https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml"
     }
   }
 }'
@@ -140,13 +140,13 @@ kubectl wait --for=condition=Ready capiprovider/harvester -n caphv-system --time
 ```bash
 kubectl get deploy caphv-controller-manager -n caphv-system \
   -o jsonpath='{.spec.template.spec.containers[0].image}'
-# Expected: ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.3.0
+# Expected: ghcr.io/rancher-sandbox/cluster-api-provider-harvester:v0.10.1
 ```
 
 3. **Patch to new version** (manual upgrade test):
 ```bash
 kubectl patch capiprovider harvester -n caphv-system --type merge -p '{
-  "spec": {"version": "v0.3.0"}
+  "spec": {"version": "v0.10.1"}
 }'
 ```
 
@@ -179,11 +179,11 @@ on that path. You can run CAPHV on any management cluster (a plain RKE2/k3s/kind
 cluster, or even Harvester's own embedded cluster) by installing the CAPI stack
 yourself.
 
-The full stack for v0.3.0 is: **CAPI core v1.12.x + cluster-api-provider-rke2
-v0.25.0 (bootstrap + control plane) + CAPHV v0.3.0**, plus cert-manager for the
+The full stack for v0.10.1 is: **CAPI core v1.12.x + cluster-api-provider-rke2
+v0.25.0 (bootstrap + control plane) + CAPHV v0.10.1**, plus cert-manager for the
 webhooks.
 
-Both methods below were validated on a clean cluster: all four controllers reach
+Both methods below were validated on a clean cluster (originally with v0.3.0; the pins below track the current release): all four controllers reach
 `1/1 Running` and the CAPHV webhook becomes Ready.
 
 ### Method A - clusterctl (recommended when Rancher is absent)
@@ -199,7 +199,7 @@ config:
 # ~/.cluster-api/clusterctl.yaml
 providers:
   - name: harvester
-    url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/v0.3.0/infrastructure-components.yaml
+    url: https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml
     type: InfrastructureProvider
 ```
 
@@ -208,20 +208,21 @@ clusterctl init \
   --core cluster-api:v1.12.8 \
   --bootstrap rke2:v0.25.0 \
   --control-plane rke2:v0.25.0 \
-  --infrastructure harvester:v0.3.0
+  --infrastructure harvester:v0.10.1
 ```
 
 > **clusterctl version**: use `clusterctl` **v1.12.x**. Older clusterctl
 > (e.g. v1.10.x) defaults CAPI core to v1.10, which is incompatible with the
-> v1beta2 contract CAPHV v0.3.0 requires.
+> v1beta2 contract CAPHV v0.3.0+ requires.
 
-> **metadata.yaml requirement**: clusterctl maps `v0.3.0` to a CAPI contract via
-> the release's `metadata.yaml`, which must contain a `0.3` series
-> (`contract: v1beta2`). If `clusterctl init` reports
-> *"version v0.3.0 ... does not match any release series. Available series:
-> [0.2, 0.1]"*, the release asset predates the fix - drop a corrected
+> **metadata.yaml requirement**: clusterctl maps each version to a CAPI contract
+> via the release's `metadata.yaml`, which must contain the matching series
+> (for v0.10.1, a `0.10` series with `contract: v1beta2`). Every release since
+> v0.3.1 declares its series. If `clusterctl init` reports
+> *"version vX.Y.Z ... does not match any release series"*, the release asset
+> predates the fix - drop a corrected
 > `metadata.yaml` into a clusterctl overrides folder:
-> `~/.cluster-api/overrides/infrastructure-harvester/v0.3.0/metadata.yaml`
+> `~/.cluster-api/overrides/infrastructure-harvester/vX.Y.Z/metadata.yaml`
 > with the `0.3 -> v1beta2` series, alongside a copy of
 > `infrastructure-components.yaml`, and re-run.
 
@@ -258,7 +259,7 @@ for c in bootstrap-components control-plane-components; do
 done
 
 # 4. CAPHV (no placeholders to render)
-kubectl apply -f https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.3.0/infrastructure-components.yaml
+kubectl apply -f https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml
 ```
 
 > Without the `render` step, the RKE2 controllers crash-loop on the literal
@@ -298,7 +299,7 @@ kubectl get harvesterclusters.infrastructure.cluster.x-k8s.io -A -o yaml > backu
 kubectl get harvestermachines.infrastructure.cluster.x-k8s.io -A -o yaml > backup-harvestermachines.yaml
 kubectl get clusters.cluster.x-k8s.io -A -o yaml > backup-clusters.yaml
 kubectl get machines.cluster.x-k8s.io -A -o yaml > backup-machines.yaml
-kubectl get ippools.ipam.cluster.x-k8s.io -A -o yaml > backup-ippools.yaml
+kubectl --kubeconfig <harvester-kubeconfig> get ippools.loadbalancer.harvesterhci.io -o yaml > backup-ippools.yaml
 ```
 
 ### Step 3: Remove the manual deployment
@@ -332,7 +333,7 @@ kubectl get crd | grep harvester
 If CRDs were removed, re-apply them before proceeding:
 
 ```bash
-kubectl apply -f https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/v0.3.0/infrastructure-components.yaml --selector='apiextensions.k8s.io/v1=CustomResourceDefinition'
+curl -sL https://github.com/rancher-sandbox/cluster-api-provider-harvester/releases/download/v0.10.1/infrastructure-components.yaml | kubectl apply -f - --server-side --field-manager=crd-restore --prune=false
 ```
 
 ### Step 4: Create the CAPIProvider resource
@@ -872,6 +873,8 @@ Requirements:
 | `spec.networks` | At least one network required |
 | `spec.networkConfig.address` | Required when networkConfig is set |
 | `spec.networkConfig.gateway` | Required and must be a valid IP when networkConfig is set |
+| `spec.vmNetworkConfig` | Mutually exclusive with `networkConfig`; requires `ipPoolRef` or `ipPoolRefs` (inline `ipPool` is rejected at the machine level); `gateway` and `subnetMask` required and must be valid IPs |
+| `spec.firmware.secureBoot` | Requires `spec.firmware.efi` to be true |
 
 ### Troubleshooting webhook issues
 
@@ -898,7 +901,7 @@ If the webhook is down and blocking operations, temporarily remove it (use with 
 kubectl delete validatingwebhookconfiguration caphv-validating-webhook-configuration
 ```
 
-The controller will re-create it on the next restart if webhooks are enabled.
+The webhook configuration ships with the components: re-apply the release manifests (or let the CAPIProvider reconcile) to restore it; the controller does not re-create it by itself.
 
 ---
 
@@ -959,6 +962,63 @@ With the control-plane HarvesterMachineTemplate attached to `default/net-cp` and
 template attached to `default/net-workers`, each machine allocates from the pool matching its
 own network. If no listed pool matches a machine's networks, allocation fails with an explicit
 error rather than handing out an address from another network.
+
+### CLI usage
+
+```bash
+# Single pool (existing behavior)
+caphv-generate --ip-pool my-pool ...
+
+# Multiple pools
+caphv-generate --ip-pool-refs "pool-a,pool-b,pool-c" ...
+```
+
+### Functional test procedure
+
+1. **Create two small IPPools** on Harvester (e.g., 2 IPs each):
+
+```bash
+# pool-a: 172.16.3.40-41 (2 IPs)
+# pool-b: 172.16.3.42-43 (2 IPs)
+```
+
+2. **Deploy a cluster with `ipPoolRefs`** referencing both pools:
+
+```bash
+caphv-generate --name multipool-test --ip-pool-refs "pool-a,pool-b" [other flags...] --apply
+```
+
+3. **Scale up to 4 machines** (2 CP + 2 workers) - should allocate from both pools:
+
+```bash
+# Verify allocations
+kubectl get harvestermachines -n multipool-test -o custom-columns=\
+  NAME:.metadata.name,IP:.status.allocatedIPAddress,POOL:.status.allocatedPoolRef
+
+# Expected: first 2 machines from pool-a, next 2 from pool-b
+```
+
+4. **Delete one machine** - verify its IP is released from the correct pool:
+
+```bash
+# Before delete: check pool-a status.allocated
+kubectl get ippools.loadbalancer.harvesterhci.io pool-a -o jsonpath='{.status.allocated}' | jq .
+
+# Delete a machine
+kubectl delete machine <machine-name> -n multipool-test
+
+# After delete: IP removed from the correct pool (pool-a or pool-b)
+kubectl get ippools.loadbalancer.harvesterhci.io pool-a -o jsonpath='{.status.allocated}' | jq .
+```
+
+5. **Unit tests** (5 new tests):
+   - `allocateVMIP` fallback from pool-1 to pool-2 when pool-1 exhausted
+   - `allocateVMIP` error when all pools exhausted
+   - `allocateVMIP` backward compat with single `ipPoolRef`
+   - `allocateVMIP` sets `AllocatedPoolRef` correctly
+   - `releaseVMIP` uses `AllocatedPoolRef` for targeted release
+
+---
 
 ### Per machine type network configuration
 
@@ -1092,63 +1152,6 @@ Notes:
 - `tpm.persistent: true` keeps the TPM state across reboots (supported by the
   KubeVirt version shipped with current Harvester releases).
 - Machines without these blocks keep booting exactly as before.
-
-### CLI usage
-
-```bash
-# Single pool (existing behavior)
-caphv-generate --ip-pool my-pool ...
-
-# Multiple pools
-caphv-generate --ip-pool-refs "pool-a,pool-b,pool-c" ...
-```
-
-### Functional test procedure
-
-1. **Create two small IPPools** on Harvester (e.g., 2 IPs each):
-
-```bash
-# pool-a: 172.16.3.40-41 (2 IPs)
-# pool-b: 172.16.3.42-43 (2 IPs)
-```
-
-2. **Deploy a cluster with `ipPoolRefs`** referencing both pools:
-
-```bash
-caphv-generate --name multipool-test --ip-pool-refs "pool-a,pool-b" [other flags...] --apply
-```
-
-3. **Scale up to 4 machines** (2 CP + 2 workers) - should allocate from both pools:
-
-```bash
-# Verify allocations
-kubectl get harvestermachines -n multipool-test -o custom-columns=\
-  NAME:.metadata.name,IP:.status.allocatedIPAddress,POOL:.status.allocatedPoolRef
-
-# Expected: first 2 machines from pool-a, next 2 from pool-b
-```
-
-4. **Delete one machine** - verify its IP is released from the correct pool:
-
-```bash
-# Before delete: check pool-a status.allocated
-kubectl get ippool pool-a -o jsonpath='{.status.allocated}' | jq .
-
-# Delete a machine
-kubectl delete machine <machine-name> -n multipool-test
-
-# After delete: IP removed from the correct pool (pool-a or pool-b)
-kubectl get ippool pool-a -o jsonpath='{.status.allocated}' | jq .
-```
-
-5. **Unit tests** (5 new tests):
-   - `allocateVMIP` fallback from pool-1 to pool-2 when pool-1 exhausted
-   - `allocateVMIP` error when all pools exhausted
-   - `allocateVMIP` backward compat with single `ipPoolRef`
-   - `allocateVMIP` sets `AllocatedPoolRef` correctly
-   - `releaseVMIP` uses `AllocatedPoolRef` for targeted release
-
----
 
 ## Backup and Disaster Recovery
 
@@ -1285,10 +1288,13 @@ ssh <user>@<vm-ip> 'sudo cloud-init status --long'
 
 ```bash
 # Check current allocations
-kubectl get ippool -n <ns> -o yaml
+kubectl get ippools.loadbalancer.harvesterhci.io -o yaml   # on the Harvester cluster; cluster-scoped
 
 # Look at allocated IPs in status
-kubectl get ippool <pool-name> -n <ns> -o jsonpath='{.status.allocated}' | jq .
+kubectl get ippools.loadbalancer.harvesterhci.io <pool-name> -o jsonpath='{.status.allocated}' | jq .
+# Note: use the full resource name (the short name resolves to Calico's IPPool on
+# Harvester) and edit allocations by patching the main object: this CRD has no
+# status subresource.
 
 # If IPs are leaked (allocated but no corresponding machine), manually edit the IPPool:
 kubectl edit ippool <pool-name> -n <ns>

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,9 +17,13 @@ Checklist for cutting a CAPHV release (`vX.Y.Z`).
 ## Release workflow
 
 The `release.yml` workflow triggers on the tag and produces: the multi-arch image on
-GHCR, the Helm OCI chart, `infrastructure-components.yaml` + `metadata.yaml` +
-cluster templates as release assets, cosign signatures (verify with **cosign v3+**:
-v2 wrongly reports "no signatures" on OCI 1.1 bundles) and build provenance.
+GHCR, the Helm OCI chart, the release assets, cosign signatures (verify with
+**cosign v3+**: v2 wrongly reports "no signatures" on OCI 1.1 bundles) and build
+provenance. Since v0.10.1 the assets are `infrastructure-components.yaml`,
+`metadata.yaml`, the six cluster template flavors (`cluster-template.yaml`,
+`-dhcp`, `-generateCPI`, `-kubeadm`, `-talos`, `-stig`) and
+`clusterclass-harvester-rke2.yaml`; earlier releases only carry the first two
+(immutability makes this impossible to fix retroactively).
 
 The GitHub release is created as a **draft** carrying all assets, and publishing it
 is the **last step**, after the image and the chart jobs succeeded. Releases are

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,7 +35,7 @@ All IPs in the configured IPPool range have been allocated. This can happen when
 1. Check the current pool state on the Harvester cluster:
    ```bash
    # On Harvester
-   kubectl get ippool <pool-name> -n <namespace> -o jsonpath='{.status.available}'
+   kubectl get ippools.loadbalancer.harvesterhci.io <pool-name> -n <namespace> -o jsonpath='{.status.available}'
    ```
 2. If the available count is 0, either expand the pool range or free leaked IPs (see IP Leak section).
 3. To expand the pool, edit the IPPool on Harvester:
@@ -62,7 +62,7 @@ The `vmNetworkConfig.ipPoolRef` in the HarvesterCluster spec references a pool n
 1. Verify the pool exists on Harvester in the correct namespace:
    ```bash
    # On Harvester
-   kubectl get ippool -A
+   kubectl get ippools.loadbalancer.harvesterhci.io -A
    ```
 2. Confirm the `ipPoolRef` value in your HarvesterCluster matches `<namespace>/<name>` or just `<name>` if the pool is in the same namespace as `targetNamespace`:
    ```bash
@@ -87,7 +87,7 @@ The CAPHV controller calls `Store.Release()` during machine deletion to free the
 1. Identify the leaked IP:
    ```bash
    # On Harvester
-   kubectl get ippool <pool-name> -n <ns> -o jsonpath='{.status.allocated}' | python3 -m json.tool
+   kubectl get ippools.loadbalancer.harvesterhci.io <pool-name> -n <ns> -o jsonpath='{.status.allocated}' | python3 -m json.tool
    ```
 2. Cross-reference with existing HarvesterMachine objects:
    ```bash
@@ -99,7 +99,7 @@ The CAPHV controller calls `Store.Release()` during machine deletion to free the
    kubectl edit ippool <pool-name> -n <ns>
    ```
    Remove the leaked entry from `status.allocated` and increment `status.available` by the number of entries removed.
-4. To prevent future leaks, ensure the CAPHV controller is always running and that HarvesterMachine finalizers (`harvestermachine.infrastructure.cluster.x-k8s.io`) are never removed manually.
+4. To prevent future leaks, ensure the CAPHV controller is always running and that HarvesterMachine finalizers (`harvestermachine.infrastructure.cluster.x-k8s.io/finalizer` (older objects may carry the legacy `harvestermachine.infrastructure.cluster.x-k8s.io`)) are never removed manually.
 
 ---
 
@@ -118,7 +118,7 @@ This was a bug in versions prior to v0.2.0 where `Store.Reserve()` did not updat
 2. For an already-affected cluster, manually resolve the conflict:
    ```bash
    # On Harvester - check allocated map
-   kubectl get ippool <pool-name> -n <ns> -o jsonpath='{.status.allocated}' | python3 -m json.tool
+   kubectl get ippools.loadbalancer.harvesterhci.io <pool-name> -n <ns> -o jsonpath='{.status.allocated}' | python3 -m json.tool
    ```
 3. Delete one of the conflicting machines and let CAPHV recreate it with a new unique IP:
    ```bash
@@ -579,7 +579,10 @@ The Turtles controller caches the CA setting. After changing `cacerts`, a contro
    # On Harvester
    kubectl get storageclass
    ```
-   For image volumes, the expected storage class is `longhorn-<imageName>`.
+   Since v0.5.2 the storage class of an image volume is read from
+`VirtualMachineImage.status.storageClassName` (recent Harvester names them
+`lh-<uuid>`); the legacy `longhorn-<imageName>` convention is only a fallback
+for images whose status is not populated yet.
 3. Fix the `imageName` in the HarvesterMachineTemplate to use `namespace/name` format:
    ```yaml
    volumes:
@@ -627,6 +630,20 @@ The `bootOrder` field in the Volume spec determines which disk KubeVirt tries to
 ---
 
 ## Machine Not Becoming Ready
+
+### Machine stuck in Provisioned with a Ready node (pre-v0.10.0)
+
+**Symptoms:** the workload node is `Ready` but its `spec.providerID` is empty,
+the Machine stays in `Provisioned` phase forever, and the controller logs stay
+silent about the machine.
+
+**Cause:** before v0.10.0, a node registering after the machine's last
+event-driven reconcile was never initialized (no requeue). Clusters with a
+MachineHealthCheck were shielded (its probes keep generating events); clusters
+without one exposed the gap.
+
+**Fix:** upgrade to v0.10.0+. On older versions, force one reconcile:
+`kubectl annotate harvestermachine <name> -n <ns> debug/kick=$(date +%s) --overwrite`.
 
 ### ProviderID Not Set
 
@@ -808,12 +825,12 @@ kubectl describe machinehealthcheck <name> -n <ns>
 
 List all IPPools and their availability:
 ```bash
-kubectl get ippool -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,AVAILABLE:.status.available
+kubectl get ippools.loadbalancer.harvesterhci.io -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,AVAILABLE:.status.available
 ```
 
 Check IP pool allocations (detailed):
 ```bash
-kubectl get ippool <name> -n <ns> -o jsonpath='{.status.allocated}' | python3 -m json.tool
+kubectl get ippools.loadbalancer.harvesterhci.io <name> -n <ns> -o jsonpath='{.status.allocated}' | python3 -m json.tool
 ```
 
 List VMs with their status:

--- a/test/certification/README.md
+++ b/test/certification/README.md
@@ -2,16 +2,18 @@
 
 This directory contains the certification suites for CAPHV (Cluster API Provider
 Harvester). They validate that a CAPHV release installs cleanly and stays compatible
-with its targeted ecosystem, in two tiers — neither needs a Harvester endpoint, so both
-run on standard CI runners:
+with its targeted ecosystem, in three tiers. The version-pairing and Rancher-stack
+tiers need no Harvester endpoint and run on standard CI runners; the Turtles
+integration tier provisions real clusters and requires a Harvester plus a self-hosted
+runner:
 
 | Tier | Suite | Stack | Trigger |
 |------|-------|-------|---------|
 | **Turtles integration** (the suite the Turtles team expects) | `suites/import-gitops/` | Full Rancher + Turtles + real Harvester: `CreateUsingGitOpsSpec` provisions a cluster, verifies Available, the Rancher auto-import (cattle-cluster-agent) and a clean deletion | self-hosted runner (needs a Harvester) |
-| **Version-pairing** (nightly) | `suites/version-pairing/` | CAPI core + RKE2 via [cluster-api-operator] — no Rancher | `certification.yml` (nightly + dispatch) |
-| **Rancher + Turtles stack** (on-demand) | `suites/rancher-turtles/` | Full released Rancher; Turtles/CAPI/RKE2 via its system chart controller — no workload cluster | `certification-tier-a.yml` (dispatch) |
+| **Version-pairing** (nightly) | `suites/version-pairing/` | CAPI core + RKE2 via [cluster-api-operator] - no Rancher | `certification.yml` (nightly + dispatch) |
+| **Rancher + Turtles stack** (on-demand) | `suites/rancher-turtles/` | Full released Rancher; Turtles/CAPI/RKE2 via its system chart controller - no workload cluster | `certification-tier-a.yml` (dispatch) |
 
-> Terminology: Turtles has no provider *certification* process — "certified" means
+> Terminology: Turtles has no provider *certification* process - "certified" means
 > "actively tested". The integration tier is the flow the Turtles team maintains in
 > [rancher/turtles-integration-suite-example]; the other two tiers are lighter
 > complements. Version pairings are recorded in [docs/compatibility.md](../../docs/compatibility.md).
@@ -44,7 +46,7 @@ providers and the CAPHV release under test, and asserts the pairing is healthy.
 3. The CAPHV CRDs are registered and advertise a `cluster.x-k8s.io/<contract>` label the
    core accepts.
 
-The bootstrap replicates `hack/tier-c-smoke.sh` — the manually validated recipe — step by
+The bootstrap replicates `hack/tier-c-smoke.sh` - the manually validated recipe - step by
 step. If you change one, keep the other in sync.
 
 ## Tier: Rancher + Turtles (on-demand)
@@ -52,7 +54,7 @@ step. If you change one, keep the other in sync.
 `suites/rancher-turtles/` certifies CAPHV under the FULL targeted Rancher: kind +
 cert-manager + nginx ingress (isolated mode), then the **released Rancher** from its
 official chart repository. Rancher's system chart controller automatically installs the
-released Turtles, the CAPI core and the RKE2 providers — the exact out-of-the-box stack
+released Turtles, the CAPI core and the RKE2 providers - the exact out-of-the-box stack
 a Rancher user gets (verified against a real Rancher 2.14.1 install). Only the CAPHV
 `CAPIProvider` (`turtles-capi.cattle.io/v1alpha1`) is applied on top.
 
@@ -62,7 +64,7 @@ label, and the certified ecosystem versions (Turtles system chart, CAPI core) ar
 recorded in the logs.
 
 > The upstream Turtles e2e flow additionally builds a local rancher/charts tree and
-> serves it from an in-cluster Gitea — that is only needed to test **unreleased**
+> serves it from an in-cluster Gitea - that is only needed to test **unreleased**
 > Turtles charts. Certifying released pairings uses Rancher's default chart repository,
 > which is the representative source, so no Gitea is involved.
 
@@ -71,9 +73,9 @@ overriding `RANCHER_VERSION` / `CAPHV_VERSION` as needed. Budget ~30-45 minutes.
 
 ## Tier: Turtles integration suite (primary, scheduled)
 
-`suites/import-gitops/` runs the Turtles `CreateUsingGitOpsSpec` — the suite the
+`suites/import-gitops/` runs the Turtles `CreateUsingGitOpsSpec` - the suite the
 Turtles team runs for every certified provider (modeled on
-`rancher/turtles-integration-suite-example`) — against a **real Harvester**:
+`rancher/turtles-integration-suite-example`) - against a **real Harvester**:
 
 1. kind + cert-manager + nginx (hostPort) + released Rancher + Turtles + CAPI core,
    plus the RKE2 providers and the CAPHV `CAPIProvider`;
@@ -95,11 +97,11 @@ kubectl plugin (`scripts/ensure-crust-gather.sh`), plus two network properties:
   endpoint (an IP from the Harvester LB pool).
 
 A plain VM on the LAN satisfies both. Rootless/NAT'd container engines on multi-bridge
-hosts often do not — nested kind networking is the first thing to check when the
+hosts often do not - nested kind networking is the first thing to check when the
 downstream agent cannot reach the server-url.
 
 In CI the suite runs on a **self-hosted runner** living inside the test environment
-(same pattern as the Turtles vSphere runner), on a schedule and manual dispatch only —
+(same pattern as the Turtles vSphere runner), on a schedule and manual dispatch only -
 never on pull requests. `HARVESTER_KUBECONFIG_B64` is provided as an Actions secret.
 
 Run manually with `MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind`,
@@ -113,11 +115,14 @@ environment:
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
-| `CAPHV_VERSION` | `v0.3.1` | CAPHV release under certification |
+| `CAPHV_VERSION` | current release (see `config.yaml`) | CAPHV release under certification |
 | `CAPHV_COMPONENTS_URL` | release asset URL | `infrastructure-components.yaml` of that release |
 | `CAPI_VERSION` | `v1.12.7` | Targeted Cluster API core (version-pairing tier) |
 | `CAPI_OPERATOR_VERSION` | `0.27.0` | cluster-api-operator helm chart (version-pairing tier) |
 | `RANCHER_VERSION` | `2.14.1` | Targeted Rancher chart (Rancher+Turtles tier) |
+| `CIS_PROFILE` | empty | When set (e.g. `cis`), the import-gitops cluster is provisioned with the RKE2 CIS profile through the ClusterClass switch |
+| `FIPS_REQUIRED` | `false` | When `true`, node bootstrap requires a FIPS-enabled node image |
+| `VM_NETWORK`, `VOLUME_IMAGE`, `SSH_USER`, `SSH_KEYPAIR`, `TARGET_NAMESPACE`, `GATEWAY`, `SUBNET_MASK`, `IP_POOL_REF`, `DNS_SERVERS` | see `config.yaml` | Harvester-side inputs of the import-gitops cluster template |
 
 The RKE2 providers deliberately carry no pin: the operator installs its latest known
 release, matching the validated recipe. cert-manager's version is pinned by the turtles
@@ -126,8 +131,8 @@ release, matching the validated recipe. cert-manager's version is pinned by the 
 ## Prerequisites
 
 - A container runtime for kind: docker, or **rootful** podman (the kind library
-  auto-detects docker → nerdctl → podman; the CLI-only `KIND_EXPERIMENTAL_PROVIDER`
-  variable has no effect here). No kind binary is needed — kind is vendored as a Go
+  auto-detects docker -> nerdctl -> podman; the CLI-only `KIND_EXPERIMENTAL_PROVIDER`
+  variable has no effect here). No kind binary is needed - kind is vendored as a Go
   library.
 - `helm` (v3+) and `kubectl` on `PATH`.
 - Go (version per `go.mod`).
@@ -182,9 +187,11 @@ test/certification/
 │   ├── version-pairing/
 │   │   ├── suite_test.go         # Bootstrap: kind -> cert-manager -> operator -> providers
 │   │   └── version_pairing_test.go  # Certification assertions
-│   └── rancher-turtles/
-│       ├── suite_test.go         # Bootstrap: kind -> ingress -> Rancher (system charts)
-│       └── rancher_turtles_test.go  # Certification assertions (tier A)
+│   ├── rancher-turtles/
+│   │   ├── suite_test.go         # Bootstrap: kind -> ingress -> Rancher (system charts)
+│   │   └── rancher_turtles_test.go  # Certification assertions (tier A)
+│   └── import-gitops/            # Turtles CreateUsingGitOpsSpec vs real Harvester
+├── scripts/ensure-crust-gather.sh # Installs the crust-gather kubectl plugin
 ├── Makefile
 ├── run.sh
 ├── go.mod                        # Standalone module (decoupled from the main CAPHV module)
@@ -197,20 +204,10 @@ After the suite passes for a new pairing, a certification issue can be submitted
 [rancher/turtles](https://github.com/rancher/turtles/issues) with the test logs, the
 CAPHV version and a link to this suite.
 
-## Tier: Turtles integration (import-gitops)
+## Running the Turtles integration tier manually
 
-Runs `CreateUsingGitOpsSpec` against a **real Harvester**: kind management cluster with
-host port mappings (`MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind`), full Rancher from
-its official chart, Turtles + CAPI core via Rancher's system chart controller, RKE2 and
-CAPHV as `CAPIProvider`s, then the full lifecycle: provision from the ClusterClass
-template → cluster Available → Rancher auto-import verified downstream → deletion
-without stalling.
-
-Environment-specific inputs (never committed): `RANCHER_HOSTNAME` must resolve to a
-host IP reachable **from the workload VMs** (e.g. `<host-lan-ip>.sslip.io`, ports 80/443
-open), and `HARVESTER_KUBECONFIG_B64`. Install crust-gather first
-(`scripts/ensure-crust-gather.sh`) so the framework collects management and downstream
-state into `_artifacts/` automatically.
+See the tier description at the top of this document for the flow and the
+environment requirements. Quick start on a suitable host:
 
 ```bash
 export RANCHER_HOSTNAME=<host-lan-ip>.sslip.io


### PR DESCRIPTION
A complete audit and refresh of every document against the current state of the project (v0.10.1).

- Installation, upgrade, clusterctl and cosign examples updated from v0.3.0/v0.5.2 to v0.10.1; the generalized metadata.yaml series note replaces the v0.3.0-era gotcha.
- README: feature table, field reference (multi-pool, machine-level `vmNetworkConfig`, firmware/TPM, affinities, failure domain), documentation index, release history v0.6.0 through v0.10.1, RKE2 example on the v1beta2 API.
- Quickstart: installs from the release assets (the CRDs already carry both contract labels) instead of a dev image with manual labelling; alpha-era caveats and outdated maturity conclusions removed.
- Compatibility matrix: new v0.6.x-v0.10.x row, including the user production deployment with three node categories on separate VLANs (#234).
- Release process: exact asset list since v0.10.1 and the immutability consequence for older releases.
- Troubleshooting: image StorageClass resolved from the image status (v0.5.2), current finalizer name, full `ippools.loadbalancer.harvesterhci.io` resource name in every command (the short name resolves to Calico's IPPool on Harvester), new entry for machines stuck Provisioned with a Ready node (fixed in v0.10.0).
- Certification README: three tiers (the integration tier does need a Harvester and a self-hosted runner), `CIS_PROFILE`/`FIPS_REQUIRED` knobs, deduplicated import-gitops sections, real repository structure.
- CONTRIBUTING: Go 1.26, branch from `main`, typed `admission.Validator[T]`, `api/v1beta1` as hub.
- Broken commands fixed: CRD-only apply via label selector (did nothing), pool backup pointing at the wrong cluster and API group.
- Wrong claims fixed: the webhook configuration is not re-created by the controller; CAAPF guidance updated for the CAPI v1.12 ecosystem.

Docs only, no code change.