### PR TITLE
ci: move the integration schedule off the morning peak

### DIFF
--- a/.github/workflows/certification-import-gitops.yml
+++ b/.github/workflows/certification-import-gitops.yml
@@ -2,7 +2,7 @@
 #
 # Runs on a self-hosted runner living inside the test environment (a VM with
 # docker, kind, helm, go and network reach to the Harvester cluster and to the
-# workload VMs it provisions) — same pattern as rancher/rancher-turtles-e2e's
+# workload VMs it provisions) - same pattern as rancher/rancher-turtles-e2e's
 # vSphere runner. The job is therefore guarded to the repository that owns the
 # runner; it never runs on pull requests.
 name: certification-import-gitops

--- a/.github/workflows/certification-import-gitops.yml
+++ b/.github/workflows/certification-import-gitops.yml
@@ -9,7 +9,9 @@ name: certification-import-gitops
 
 on:
   schedule:
-    - cron: "0 3 * * 1,4"
+    # Off-peak for the current self-hosted environment, and off the top of the
+    # hour (GitHub delays popular schedule slots by up to a few hours).
+    - cron: "37 11 * * 1,4"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
The scheduled integration runs (cron 3:00 UTC, delayed by GitHub to about 5:30) failed three times in a row (Jul 30, Aug 3, Aug 6) with the workload control plane missing its 20 minute startup window, while every daytime dispatch of the exact same code passed (including a confirmation run today). Root cause is environmental: the delayed schedule lands in the local morning peak of the self-hosted environment's uplink, and the node image pulls become too slow for the MachineHealthCheck window.

Move the schedule to 11:37 UTC (a window every green run has used) and off the top of the hour to reduce GitHub's scheduling delay. The job only executes on the runner-owning fork (`repository_owner` guard), so the change is inert for this repository; it just keeps the biweekly certification signal green until the team-owned runner replaces the current one.