### PR TITLE
ci: optional registry mirror for the workload nodes

### DIFF
--- a/.github/workflows/certification-import-gitops.yml
+++ b/.github/workflows/certification-import-gitops.yml
@@ -35,6 +35,10 @@ jobs:
         working-directory: test/certification
         env:
           HARVESTER_KUBECONFIG_B64: ${{ secrets.HARVESTER_KUBECONFIG_B64 }}
+          # Optional docker.io pull-through mirror for the workload nodes
+          # (unauthenticated Docker Hub pulls are rate limited per IP; a full
+          # run plus background traffic can starve the control plane pulls).
+          REGISTRY_MIRROR_ENDPOINT: ${{ vars.REGISTRY_MIRROR_ENDPOINT }}
         run: |
           # The Rancher server-url must be reachable both from inside the kind
           # cluster and from the workload VMs: the runner VM's LAN IP is.
@@ -45,6 +49,7 @@ jobs:
             MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind \
             RANCHER_HOSTNAME="$RANCHER_HOSTNAME" \
             HARVESTER_KUBECONFIG_B64="$HARVESTER_KUBECONFIG_B64" \
+            REGISTRY_MIRROR_ENDPOINT="$REGISTRY_MIRROR_ENDPOINT" \
             ./bin/import-gitops.test -test.timeout 140m -test.v -ginkgo.v
 
       - name: Collect artifacts

--- a/test/certification/config/config.yaml
+++ b/test/certification/config/config.yaml
@@ -62,7 +62,7 @@ variables:
   # Import-gitops tier only (full lifecycle on a real Harvester): the suite runs with
   # MANAGEMENT_CLUSTER_ENVIRONMENT=internal-kind and needs RANCHER_HOSTNAME resolving to
   # a host IP reachable from the workload VMs (e.g. <host-lan-ip>.sslip.io), plus
-  # HARVESTER_KUBECONFIG_B64 — both are environment-specific and supplied by the wrapper
+  # HARVESTER_KUBECONFIG_B64 - both are environment-specific and supplied by the wrapper
   # or CI, never committed here.
   NAMESPACE: "default"
   KUBERNETES_VERSION: "v1.31.14"
@@ -84,3 +84,4 @@ variables:
   CNI: "calico"
   CIS_PROFILE: ""
   FIPS_REQUIRED: "false"
+  REGISTRY_MIRROR_ENDPOINT: ""

--- a/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
+++ b/test/certification/suites/data/cluster-templates/harvester-rke2-topology.yaml
@@ -146,6 +146,12 @@ spec:
         openAPIV3Schema:
           type: boolean
           default: false
+    - name: registryMirrorEndpoint
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: ""
   patches:
     - name: vmNetworks
       definitions:
@@ -460,6 +466,39 @@ spec:
                   - printf "vm.panic_on_oom=0\nvm.overcommit_memory=1\nkernel.panic=10\nkernel.panic_on_oops=1\n" > /etc/sysctl.d/90-kubelet.conf
                   - sysctl -p /etc/sysctl.d/90-kubelet.conf
                   {{ end }}
+    - name: registryMirror
+      enabledIf: '{{ if .registryMirrorEndpoint }}true{{ end }}'
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: RKE2ControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/privateRegistriesConfig
+              valueFrom:
+                template: |
+                  mirrors:
+                    docker.io:
+                      endpoint:
+                        - {{ .registryMirrorEndpoint }}
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+            kind: RKE2ConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/privateRegistriesConfig
+              valueFrom:
+                template: |
+                  mirrors:
+                    docker.io:
+                      endpoint:
+                        - {{ .registryMirrorEndpoint }}
     - name: csiAddonConfigMap
       definitions:
         - selector:
@@ -652,8 +691,10 @@ spec:
         value: "${CIS_PROFILE}"
       - name: fipsRequired
         value: ${FIPS_REQUIRED}
+      - name: registryMirrorEndpoint
+        value: "${REGISTRY_MIRROR_ENDPOINT}"
 ---
-# ClusterResourceSet — CSI plugin DaemonSet + RBAC
+# ClusterResourceSet - CSI plugin DaemonSet + RBAC
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -668,7 +709,7 @@ spec:
       name: cloud-controller-manager-addon-${CLUSTER_NAME}
   strategy: Reconcile
 ---
-# ClusterResourceSet — Cloud provider Deployment + RBAC
+# ClusterResourceSet - Cloud provider Deployment + RBAC
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -683,7 +724,7 @@ spec:
       name: harvester-csi-driver-addon-${CLUSTER_NAME}
   strategy: Reconcile
 ---
-# ClusterResourceSet — Calico HelmChartConfig
+# ClusterResourceSet - Calico HelmChartConfig
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -698,7 +739,7 @@ spec:
       name: calico-helm-config-${CLUSTER_NAME}
   strategy: ApplyOnce
 ---
-# ConfigMap — Harvester CSI plugin DaemonSet
+# ConfigMap - Harvester CSI plugin DaemonSet
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -877,7 +918,7 @@ data:
     reclaimPolicy: Delete
     volumeBindingMode: Immediate
 ---
-# ConfigMap — Harvester cloud provider Deployment (with bootstrap fixes)
+# ConfigMap - Harvester cloud provider Deployment (with bootstrap fixes)
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -996,7 +1037,7 @@ data:
         name: harvester-cloud-controller-manager
         namespace: kube-system
 ---
-# ConfigMap — Calico HelmChartConfig
+# ConfigMap - Calico HelmChartConfig
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
The integration runs fail whenever the shared egress IP exhausts Docker Hub's anonymous pull quota (100 pulls per hour per IP, verified against the rate-limit headers): the workload control plane pulls its images last in the sequence and starves, which produced both the recurring early-schedule failures and yesterday's afternoon one, while lighter-traffic hours passed.

- New `registryMirrorEndpoint` ClusterClass variable in the suite template: when set, the control plane and worker RKE2 configs gain a `privateRegistriesConfig` docker.io mirror; empty default keeps the current behavior.
- The workflow feeds it from an optional Actions **variable** (`vars.REGISTRY_MIRROR_ENDPOINT`), so each runner environment points at its own pull-through cache with nothing environment-specific in the repository. A simple `registry:2` container with `REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io` on the runner's network is enough; after the first run the cache serves almost every workload pull.

This also benefits the future team-owned runner: any shared or NATed egress hits the same quota.